### PR TITLE
Performance scale

### DIFF
--- a/assets/entrypoint
+++ b/assets/entrypoint
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-export DIRECTOR_SERVER_ADDRESS=${DIRECTOR_SERVER_ADDRESS:-localhost}
-export DIRECTOR_MODE=${DIRECTOR_MODE:-client}
+export DIRECTORD_SERVER_ADDRESS=${DIRECTORD_SERVER_ADDRESS:-localhost}
+export DIRECTORD_MODE=${DIRECTORD_MODE:-client}
 
-if [ "${DIRECTOR_MODE}" = "server" ]; then
+if [ "${DIRECTORD_MODE}" = "server" ]; then
     /directord/bin/directord --socket-path /tmp/directord.sock server
 else
-    /directord/bin/directord client --server-address ${DIRECTOR_SERVER_ADDRESS}
+    /directord/bin/directord client --server-address ${DIRECTORD_SERVER_ADDRESS}
 fi

--- a/assets/pod-director-client.yaml
+++ b/assets/pod-director-client.yaml
@@ -25,7 +25,7 @@ spec:
       value: xterm
     - name: container
       value: oci
-    - name: DIRECTOR_MODE
+    - name: DIRECTORD_MODE
       value: client
     - name: HOSTNAME
       value: directord

--- a/assets/pod-director-server.yaml
+++ b/assets/pod-director-server.yaml
@@ -25,7 +25,7 @@ spec:
       value: xterm
     - name: container
       value: oci
-    - name: DIRECTOR_MODE
+    - name: DIRECTORD_MODE
       value: server
     - name: HOSTNAME
       value: directord

--- a/directord/main.py
+++ b/directord/main.py
@@ -22,7 +22,7 @@ def _args():
         "--config-file",
         help="File path for client configuration. Default: %(default)s",
         metavar="STRING",
-        default=os.getenv("DIRECTOR_CONFIG_FILE"),
+        default=os.getenv("DIRECTORD_CONFIG_FILE"),
         type=argparse.FileType(mode="r"),
     )
     auth_group = parser.add_mutually_exclusive_group()
@@ -30,7 +30,7 @@ def _args():
         "--shared-key",
         help="Shared key used for server client authentication.",
         metavar="STRING",
-        default=os.getenv("DIRECTOR_SHARED_KEY"),
+        default=os.getenv("DIRECTORD_SHARED_KEY"),
     )
     auth_group.add_argument(
         "--curve-encryption",
@@ -50,28 +50,28 @@ def _args():
         "--job-port",
         help="Job port to bind. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_MSG_PORT", 5555)),
+        default=int(os.getenv("DIRECTORD_MSG_PORT", 5555)),
         type=int,
     )
     parser.add_argument(
         "--transfer-port",
         help="Transfer port to bind. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_TRANSFER_PORT", 5556)),
+        default=int(os.getenv("DIRECTORD_TRANSFER_PORT", 5556)),
         type=int,
     )
     parser.add_argument(
         "--heartbeat-port",
         help="heartbeat port to bind. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_HEARTBEAT_PORT", 5557)),
+        default=int(os.getenv("DIRECTORD_HEARTBEAT_PORT", 5557)),
         type=int,
     )
     parser.add_argument(
         "--heartbeat-interval",
         help="heartbeat interval in seconds. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_HEARTBEAT_INTERVAL", 60)),
+        default=int(os.getenv("DIRECTORD_HEARTBEAT_INTERVAL", 60)),
         type=int,
     )
     parser.add_argument(
@@ -82,7 +82,7 @@ def _args():
         ),
         metavar="STRING",
         default=str(
-            os.getenv("DIRECTOR_SOCKET_PATH", "/var/run/directord.sock")
+            os.getenv("DIRECTORD_SOCKET_PATH", "/var/run/directord.sock")
         ),
         type=str,
     )
@@ -90,7 +90,7 @@ def _args():
         "--cache-path",
         help=("Client cache path." " Default: %(default)s"),
         metavar="STRING",
-        default=str(os.getenv("DIRECTOR_CACHE_PATH", "/var/cache/directord")),
+        default=str(os.getenv("DIRECTORD_CACHE_PATH", "/var/cache/directord")),
         type=str,
     )
     subparsers = parser.add_subparsers(
@@ -170,19 +170,19 @@ def _args():
         "--bind-address",
         help="IP Address to bind a Directord Server. Default: %(default)s",
         metavar="STRING",
-        default=os.getenv("DIRECTOR_BIND_ADDRESS", "*"),
+        default=os.getenv("DIRECTORD_BIND_ADDRESS", "*"),
     )
     parser_server.add_argument(
         "--etcd-server",
         help="Domain or IP address of the ETCD server. Default: %(default)s",
         metavar="STRING",
-        default=os.getenv("DIRECTOR_ETCD_SERVER", "localhost"),
+        default=os.getenv("DIRECTORD_ETCD_SERVER", "localhost"),
     )
     parser_server.add_argument(
         "--etcd-port",
         help="ETCD server bind port. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_ETCD_PORT", 2379)),
+        default=int(os.getenv("DIRECTORD_ETCD_PORT", 2379)),
         type=int,
     )
     parser_server.add_argument(
@@ -194,7 +194,7 @@ def _args():
         "--ui-port",
         help="UI server bind port. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_UI_PORT", 9000)),
+        default=int(os.getenv("DIRECTORD_UI_PORT", 9000)),
         type=int,
     )
     parser_client = subparsers.add_parser("client", help="Client mode help")
@@ -205,7 +205,7 @@ def _args():
             " Default: %(default)s"
         ),
         metavar="STRING",
-        default=os.getenv("DIRECTOR_SERVER_ADDRESS", "localhost"),
+        default=os.getenv("DIRECTORD_SERVER_ADDRESS", "localhost"),
     )
     parser_manage = subparsers.add_parser(
         "manage", help="Server management mode help"
@@ -269,13 +269,13 @@ def _args():
             " Default: %(default)s"
         ),
         metavar="STRING",
-        default=os.getenv("DIRECTOR_BOOTSTRAP_SSH_KEY_FILE"),
+        default=os.getenv("DIRECTORD_BOOTSTRAP_SSH_KEY_FILE"),
     )
     parser_bootstrap.add_argument(
         "--threads",
         help="Client bootstrap threads. Default: %(default)s",
         metavar="INT",
-        default=int(os.getenv("DIRECTOR_BOOTSTRAP_THREADS", 10)),
+        default=int(os.getenv("DIRECTORD_BOOTSTRAP_THREADS", 10)),
         type=int,
     )
     args = parser.parse_args()

--- a/directord/main.py
+++ b/directord/main.py
@@ -269,10 +269,7 @@ def _args():
             " Default: %(default)s"
         ),
         metavar="STRING",
-        default=os.getenv(
-            "DIRECTOR_BOOTSTRAP_SSH_KEY_FILE",
-            os.path.join(os.environ["HOME"], ".ssh", "id_rsa"),
-        ),
+        default=os.getenv("DIRECTOR_BOOTSTRAP_SSH_KEY_FILE"),
     )
     parser_bootstrap.add_argument(
         "--threads",

--- a/directord/mixin.py
+++ b/directord/mixin.py
@@ -370,7 +370,7 @@ class Mixin(object):
                 host=job_def["host"],
                 username=job_def["username"],
                 port=job_def["port"],
-                key_file=job_def["key_file"],
+                key_file=job_def.get("key_file"),
             ) as conn:
                 ssh, session = conn
                 if key == "RUN":

--- a/directord/server.py
+++ b/directord/server.py
@@ -156,16 +156,18 @@ class Server(manager.Interface):
             job_metadata["INFO"][identity] = job_output
             if not _createtime:
                 job_metadata["_createtime"] = time.time()
-            self.log.info("{} received job {}".format(identity, job_id))
+            self.log.debug("{} received job {}".format(identity, job_id))
         elif job_status == self.job_processing:
             job_metadata["PROCESSING"] = True
             job_metadata["SUCCESS"] = False
             job_metadata["INFO"][identity] = job_output
             if not _starttime:
                 job_metadata["_starttime"] = time.time()
-            self.log.info("{} is processing {}".format(identity, job_id))
+            self.log.debug("{} is processing {}".format(identity, job_id))
         elif job_status in [self.job_end, self.nullbyte]:
-            self.log.info("{} finished processing {}".format(identity, job_id))
+            self.log.debug(
+                "{} finished processing {}".format(identity, job_id)
+            )
             job_metadata["PROCESSING"] = False
             job_metadata["SUCCESS"] = True
             job_metadata["INFO"][identity] = job_output
@@ -341,7 +343,7 @@ class Server(manager.Interface):
                         data=json.dumps(job_item).encode(),
                     )
 
-                self.log.info("Sent job {} to {}".format(task, identity))
+                self.log.debug("Sent job {} to {}".format(task, identity))
             else:
                 self.return_jobs[task] = job_info
 

--- a/docs/containerization.md
+++ b/docs/containerization.md
@@ -50,7 +50,7 @@ $ mkdir -p ~/local/share/directord ~/local/share/directord/etc
 $ podman run --hostname directord \
              --name directord-server \
              --net=host \
-             --env DIRECTOR_MODE=server \
+             --env DIRECTORD_MODE=server \
              --volume ${HOME}/local/share/directord/etc:/etc/directord:z \
              --volume ${HOME}/local/share/directord:${HOME}/local/share/directord \
              --detach \
@@ -89,14 +89,14 @@ $ directord --socket-path /tmp/directord.sock manage --list-nodes
 $ podman run --hostname $(hostname)-client \
              --name directord-client \
              --net=host \
-             --env DIRECTOR_SERVER_ADDRESS=172.16.27.120 \
-             --env DIRECTOR_SHARED_KEY=secrete \
+             --env DIRECTORD_SERVER_ADDRESS=172.16.27.120 \
+             --env DIRECTORD_SHARED_KEY=secrete \
              --user 0 \
              --detach \
              directord directord
 ```
 
-> NOTE: the DIRECTOR_SERVER_ADDRESS environment variable needs to point to the
+> NOTE: the DIRECTORD_SERVER_ADDRESS environment variable needs to point to the
   IP address or Domain name of the Directord server.
 
 #### Running pods

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,8 +18,8 @@ $ for i in {1..40}; do
   podman run --hostname $(hostname)-client-${i} \
              --name $(hostname)-client-${i} \
              --net=host \
-             --env DIRECTOR_SERVER_ADDRESS=127.0.0.1 \
-             --env DIRECTOR_SHARED_KEY=secrete \
+             --env DIRECTORD_SERVER_ADDRESS=127.0.0.1 \
+             --env DIRECTORD_SHARED_KEY=secrete \
              --user 0 \
              --detach \
              directord directord

--- a/orchestrations/scale-test-setup.yaml
+++ b/orchestrations/scale-test-setup.yaml
@@ -9,13 +9,15 @@
 - jobs:
   - RUN: dnf install -y podman
   - RUN: podman pull quay.io/cloudnull/directord:stable
-  - RUN: |-
+  - RUN: podman tag quay.io/cloudnull/directord:stable directord
+  - RUN: >-
       for i in {0..49}; do
-        podman run --hostname $(hostname)-client \
-                   --name directord-client \
-                   --net=host \
-                   --volume /etc/directord:/etc/directord:z \
-                   --user 0 \
-                   --detach \
-                   directord directord
+      podman run --hostname $(hostname)-client-${i}
+                 --name directord-client-${i}
+                 --net=host
+                 --env DIRECTORD_CONFIG_FILE=/etc/directord/config.yaml
+                 --volume /etc/directord:/etc/directord:z
+                 --user 0
+                 --detach
+                 directord directord;
       done

--- a/orchestrations/scale-test.yaml
+++ b/orchestrations/scale-test.yaml
@@ -1,0 +1,21 @@
+# This orchestration will create containerized instances of directord client
+# which will allow developers to test environment interactions at scale.
+#
+# Scale operations will pull and run 50 instances per-host within the directord
+# cluster and will bind to the configuration deployed within the existing node.
+#
+---
+
+- jobs:
+  - RUN: dnf install -y podman
+  - RUN: podman pull quay.io/cloudnull/directord:stable
+  - RUN: |-
+      for i in {0..49}; do
+        podman run --hostname $(hostname)-client \
+                   --name directord-client \
+                   --net=host \
+                   --volume /etc/directord:/etc/directord:z \
+                   --user 0 \
+                   --detach \
+                   directord directord
+      done

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     description=(
         "A deployment framework built to manage the data center" " life cycle."
     ),
-    version="0.1.3",
+    version="0.1.4",
     packages=["directord"],
     include_package_data=True,
     zip_safe=False,

--- a/tools/directord-inventory-catalog.yaml
+++ b/tools/directord-inventory-catalog.yaml
@@ -1,6 +1,6 @@
 directord_server:
   targets:
-  - host: 172.16.27.96
+  - host: 172.16.27.97
     port: 22
     username: centos
 
@@ -9,11 +9,11 @@ directord_clients:
     port: 22
     username: centos
   targets:
-  - host: 172.16.27.96
-  - host: 172.16.27.129
-  - host: 172.16.27.99
-  - host: 172.16.27.242
-  - host: 172.16.27.200
-  - host: 172.16.27.189
-  - host: 172.16.27.231
-  - host: 172.16.27.91
+  - host: 172.16.27.97
+  - host: 172.16.27.221
+  - host: 172.16.27.98
+  - host: 172.16.27.164
+  - host: 172.16.27.68
+  - host: 172.16.27.46
+  - host: 172.16.27.215
+  - host: 172.16.27.100


### PR DESCRIPTION
This change implements a performance and scale test orchestration example.

Additionally changes have been made to the server code to further improve scale operations.

Using the test setup with 408 nodes and the `ssh-keygen-distribute.yaml` orchestration example we saw an execution time of **2549.27**. After the scale and performance improvements we the time was reduced to **516.51**.

Quality of life changes have been added to ensure a better operator experience.