### PR TITLE
Libssh > Paramiko

### DIFF
--- a/directord/main.py
+++ b/directord/main.py
@@ -303,6 +303,7 @@ def _args(exec_args=None):
         help="File path for SSH catalog.",
         metavar="STRING",
         action="append",
+        required=True,
         type=argparse.FileType(mode="r"),
     )
     parser_bootstrap.add_argument(

--- a/directord/meta.py
+++ b/directord/meta.py
@@ -12,6 +12,6 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __author__ = "Kevin Carter"
 __email__ = "kevin@cloudnull.com"

--- a/directord/tests/test_utils.py
+++ b/directord/tests/test_utils.py
@@ -13,14 +13,16 @@
 #   under the License.
 
 import unittest
+from unittest import mock
 import uuid
 
 from unittest.mock import patch
 
+from directord import tests
 from directord import utils
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(tests.TestConnectionBase):
     def test_dump_yaml(self):
         m = unittest.mock.mock_open()
         with patch("builtins.open", m):
@@ -98,21 +100,14 @@ class TestUtils(unittest.TestCase):
             stdout=unittest.mock.ANY,
         )
 
-    @patch("directord.utils.paramiko.RSAKey", autospec=True)
-    @patch("directord.utils.paramiko.SSHClient", autospec=True)
-    def test_paramikoconnect(self, mock_sshclient, mock_rsakey):
-        with utils.ParamikoConnect(
+    def test_sshconnect(
+        self,
+    ):
+        with utils.SSHConnect(
             host="test", username="testuser", port=22, key_file="/test/key"
         ) as ssh:
-            self.assertEqual(ssh, mock_sshclient())
-            ssh.connect.assert_called_once_with(
-                allow_agent=True,
-                hostname="test",
-                pkey=unittest.mock.ANY,
-                port=22,
-                username="testuser",
-            )
-        ssh.close.assert_called_once_with()
+            ssh.session.handshake(mock.ANY)
+            ssh.session.knownhost_init()
 
     def test_file_sha1(self):
         with unittest.mock.patch(

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ setuptools.setup(
     install_requires=[
         "diskcache",
         "jinja2",
-        "paramiko",
         "pyyaml",
         "pyzmq",
+        "ssh2-python",
         "tabulate",
         "tenacity",
     ],

--- a/tools/prod-setup.sh
+++ b/tools/prod-setup.sh
@@ -4,13 +4,13 @@ set -eo
 . /etc/os-release
 if [[ ${ID} == "rhel" ]] || [[ ${ID} == "centos" ]]; then
   dnf -y install https://www.rdoproject.org/repos/rdo-release.el8.rpm
-  PACKAGES="git python3 python3-paramiko python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium"
+  PACKAGES="git python3 python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium"
   dnf -y install ${PACKAGES}
 elif [[ ${ID} == "fedora" ]]; then
-  PACKAGES="git python3 python3-paramiko python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium python3-diskcache"
+  PACKAGES="git python3 python3-ssh2-python python3-tenacity python3-tabulate python3-zmq python3-pyyaml python3-jinja2 zeromq libsodium python3-diskcache"
   dnf -y install ${PACKAGES}
 elif [[ ${ID} == "ubuntu" ]]; then
-  PACKAGES="git python3-all python3-venv python3-paramiko python3-tabulate python3-zmq python3-yaml python3-jinja2"
+  PACKAGES="git python3-all python3-venv python3-tabulate python3-zmq python3-yaml python3-jinja2"
   apt update
   apt -y install ${PACKAGES}
 else


### PR DESCRIPTION
this change updates our ssh implementation to use libssh instead of paramiko, which allows us to meet FIPs requirements within the bootstrap codepath.