### PR TITLE
Add logging around permission errors for socket

### DIFF
--- a/directord/__init__.py
+++ b/directord/__init__.py
@@ -41,16 +41,24 @@ def send_data(socket_path, data):
     :returns: String
     """
 
-    with UNIXSocketConnect(socket_path) as s:
-        s.sendall(data.encode())
-        fragments = []
-        while True:
-            chunk = s.recv(1024)
-            if not chunk:
-                break
+    try:
+        with UNIXSocketConnect(socket_path) as s:
+            s.sendall(data.encode())
+            fragments = []
+            while True:
+                chunk = s.recv(1024)
+                if not chunk:
+                    break
 
-            fragments.append(chunk)
-        return b"".join(fragments)
+                fragments.append(chunk)
+            return b"".join(fragments)
+    except PermissionError:
+        log = logger.getLogger(name="directord")
+        log.error(
+            "Permission error writing to %s. Check write permissions.",
+            socket_path,
+        )
+        raise
 
 
 def plugin_import(plugin):


### PR DESCRIPTION
If you attempt to connect to the directord socket as a user that cannot
write to the socket, a permission exception is thrown but no details
indicating what file are provided to the user. This catches the
Permission error and prints out the socket path for use in
troubleshooting.

Signed-off-by: Alex Schultz <aschultz@redhat.com>