### PR TITLE
Add group abilities

### DIFF
--- a/contrib/container-build/directord.spec
+++ b/contrib/container-build/directord.spec
@@ -46,9 +46,9 @@ Requires:       python3-tenacity
 # Source Requirements
 # TODO(cloudnull): This needs to be packaged officially
 Requires:       python3-diskcache
-Requires:       python3-ssh2-python
 
 # Recommends
+Recommends:       python3-ssh2-python
 Recommends:       python3-zmq
 Recommends:       python3-redis
 Recommends:       python3-flask
@@ -65,6 +65,11 @@ simplicity, faster time to delivery, and consistency. Design PrinciplesThe
 Directord design principles can be [found here]( DocumentationAdditional
 documentation covering...
 
+Requires(pre):    shadow-utils
+
+%pre
+getent group directord >/dev/null || groupadd -r directord
+exit 0
 
 %prep
 %autosetup -n %{pypi_name}

--- a/directord/components/builtin_transfer.py
+++ b/directord/components/builtin_transfer.py
@@ -68,7 +68,7 @@ class Component(components.ComponentBase):
             data["user"], data["group"] = chown
 
         if self.known_args.chmod:
-            data["mode"] = oct(int(self.known_args.chmod, 8))
+            data["mode"] = int(oct(int(self.known_args.chmod, 8)), 8)
 
         file_from, data["to"] = shlex.split(" ".join(self.known_args.files))
         data["from"] = [

--- a/directord/components/builtin_workdir.py
+++ b/directord/components/builtin_workdir.py
@@ -56,7 +56,7 @@ class Component(components.ComponentBase):
             data["user"], data["group"] = chown
 
         if self.known_args.chmod:
-            data["mode"] = oct(int(self.known_args.chmod, 8))
+            data["mode"] = int(oct(int(self.known_args.chmod, 8)), 8)
 
         data["workdir"] = self.known_args.workdir
         return data

--- a/directord/server.py
+++ b/directord/server.py
@@ -12,6 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import grp
 import json
 import multiprocessing
 import os
@@ -585,6 +586,14 @@ class Server(interface.Interface):
 
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.bind(self.args.socket_path)
+        os.chmod(self.args.socket_path, 509)
+        uid = 0
+        group = getattr(self.args, "socket_group", "root")
+        try:
+            gid = int(group)
+        except ValueError:
+            gid = grp.getgrnam(group).gr_gid
+        os.chown(self.args.socket_path, uid, gid)
         sock.listen(1)
         while True:
             conn, _ = sock.accept()

--- a/directord/templates/directord-client.service.j2
+++ b/directord/templates/directord-client.service.j2
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 User=root
-ExecStart=/usr/bin/directord --config-file /etc/directord/config.yaml server
+Group={{ directord_group }}
+ExecStart={{ directord_binary }} --config-file /etc/directord/config.yaml client
 Restart=on-failure
 RestartSec=10
 CPUAccounting=true

--- a/directord/templates/directord-server.service.j2
+++ b/directord/templates/directord-server.service.j2
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 User=root
-ExecStart=/usr/bin/directord --config-file /etc/directord/config.yaml client
+Group={{ directord_group }}
+ExecStart={{ directord_binary }} --config-file /etc/directord/config.yaml server
 Restart=on-failure
 RestartSec=10
 CPUAccounting=true

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -90,6 +90,7 @@ class FakeArgs:
     server_address = "localhost"
     shared_key = None
     socket_path = "/var/run/directord.sock"
+    socket_group = "root"
     cache_path = "/var/cache/directord"
     transfer_port = 5556
     curve_encryption = None

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -56,6 +56,7 @@ class TestMain(unittest.TestCase):
                 "heartbeat_port": 5557,
                 "ignore_cache": False,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "orchestrate",
@@ -82,6 +83,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -108,6 +110,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -134,6 +137,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -160,6 +164,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -186,6 +191,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -213,6 +219,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -239,6 +246,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -265,6 +273,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -291,6 +300,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "exec",
@@ -316,6 +326,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "server",
@@ -340,6 +351,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "mode": "client",
@@ -366,6 +378,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -395,6 +408,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": True,
@@ -424,6 +438,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -453,6 +468,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -482,6 +498,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -511,6 +528,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -540,6 +558,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -569,6 +588,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "cache_path": "/var/cache/directord",
                 "list_jobs": False,
@@ -598,6 +618,7 @@ class TestMain(unittest.TestCase):
                 "transfer_port": 5556,
                 "heartbeat_port": 5557,
                 "heartbeat_interval": 60,
+                "socket_group": "0",
                 "socket_path": "/var/run/directord.sock",
                 "threads": 10,
                 "cache_path": "/var/cache/directord",
@@ -629,17 +650,19 @@ class TestMain(unittest.TestCase):
             m.assert_not_called()
         mock_makedirs.assert_called()
 
+    @patch("jinja2.FileSystemLoader", autospec=True)
     @patch("builtins.print")
     @patch("os.path.exists", autospec=True)
     @patch("os.makedirs", autospec=True)
     def test_systemdinstall_writer(
-        self, mock_makedirs, mock_exists, mock_print
+        self, mock_makedirs, mock_exists, mock_print, mock_jinja
     ):
         mock_exists.return_value = False
         with patch("builtins.open", unittest.mock.mock_open()) as m:
             main.SystemdInstall().writer(service_file="testfile")
             m.assert_called()
         mock_print.assert_called()
+        mock_jinja.assert_called()
 
     @patch("builtins.print")
     @patch("os.path.exists", autospec=True)
@@ -653,11 +676,12 @@ class TestMain(unittest.TestCase):
             m.assert_not_called()
         mock_print.assert_called()
 
+    @patch("jinja2.FileSystemLoader", autospec=True)
     @patch("builtins.print")
     @patch("os.path.exists", autospec=True)
     @patch("os.makedirs", autospec=True)
     def test_systemdinstall_server(
-        self, mock_makedirs, mock_exists, mock_print
+        self, mock_makedirs, mock_exists, mock_print, mock_jinja
     ):
         mock_exists.return_value = False
         with patch("builtins.open", unittest.mock.mock_open()) as m:
@@ -668,12 +692,14 @@ class TestMain(unittest.TestCase):
                 "/etc/systemd/system/directord-client.service", "w"
             )
         mock_print.assert_called()
+        mock_jinja.assert_called()
 
+    @patch("jinja2.FileSystemLoader", autospec=True)
     @patch("builtins.print")
     @patch("os.path.exists", autospec=True)
     @patch("os.makedirs", autospec=True)
     def test_systemdinstall_client(
-        self, mock_makedirs, mock_exists, mock_print
+        self, mock_makedirs, mock_exists, mock_print, mock_jinja
     ):
         mock_exists.return_value = False
         with patch("builtins.open", unittest.mock.mock_open()) as m:
@@ -684,6 +710,7 @@ class TestMain(unittest.TestCase):
                 "/etc/systemd/system/directord-server.service", "w"
             )
         mock_print.assert_called()
+        mock_jinja.assert_called()
 
     @patch("directord.main._args", autospec=True)
     def test_main_server(self, mock__args):

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -668,21 +668,29 @@ class TestServer(tests.TestDriverBase):
             job_stderr=None,
         )
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
-    def test_run_socket_server(self, mock_socket, mock_unlink):
+    def test_run_socket_server(
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
+    ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
         conn.recv.return_value = json.dumps({}).encode()
         socket.accept.return_value = [conn, MagicMock()]
         self.server.run_socket_server(sentinel=True)
         mock_unlink.assert_called_with(self.args.socket_path)
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("time.time", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
     def test_run_socket_server_manage_list_nodes(
-        self, mock_socket, mock_unlink, mock_time
+        self, mock_socket, mock_unlink, mock_time, mock_chmod, mock_chown
     ):
         mock_time.return_value = 1
         socket = mock_socket.return_value = MagicMock()
@@ -704,11 +712,15 @@ class TestServer(tests.TestDriverBase):
                 ]
             ).encode()
         )
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
     def test_run_socket_server_manage_list_jobs(
-        self, mock_socket, mock_unlink
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
     ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
@@ -719,11 +731,15 @@ class TestServer(tests.TestDriverBase):
         self.server.run_socket_server(sentinel=True)
         mock_unlink.assert_called_with(self.args.socket_path)
         conn.sendall.assert_called_with(b'[["k", {"v": "test"}]]')
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
     def test_run_socket_server_manage_purge_nodes(
-        self, mock_socket, mock_unlink
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
     ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
@@ -737,11 +753,15 @@ class TestServer(tests.TestDriverBase):
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.workers, {})
         conn.sendall.assert_called_with(b'{"success": true}')
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
     def test_run_socket_server_manage_purge_jobs(
-        self, mock_socket, mock_unlink
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
     ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
@@ -754,10 +774,16 @@ class TestServer(tests.TestDriverBase):
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b'{"success": true}')
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
-    def test_run_socket_server_run(self, mock_socket, mock_unlink):
+    def test_run_socket_server_run(
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
+    ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
         conn.recv.return_value = json.dumps(
@@ -776,10 +802,16 @@ class TestServer(tests.TestDriverBase):
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b"Job received. Task ID: XXX")
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
+    @patch("os.chown", autospec=True)
+    @patch("os.chmod", autospec=True)
     @patch("os.unlink", autospec=True)
     @patch("socket.socket", autospec=True)
-    def test_run_socket_server_run_raw(self, mock_socket, mock_unlink):
+    def test_run_socket_server_run_raw(
+        self, mock_socket, mock_unlink, mock_chmod, mock_chown
+    ):
         socket = mock_socket.return_value = MagicMock()
         conn = MagicMock()
         conn.recv.return_value = json.dumps(
@@ -798,6 +830,8 @@ class TestServer(tests.TestDriverBase):
         mock_unlink.assert_called_with(self.args.socket_path)
         self.assertDictEqual(self.server.return_jobs, {})
         conn.sendall.assert_called_with(b"XXX")
+        mock_chmod.assert_called()
+        mock_chown.assert_called()
 
     @patch("directord.server.Server.run_threads", autospec=True)
     def test_worker_run(self, mock_run_threads):

--- a/tools/directord-prod-bootstrap-catalog.yaml
+++ b/tools/directord-prod-bootstrap-catalog.yaml
@@ -7,7 +7,8 @@ directord_server:
   - RUN: >-
       [[ ! -f /etc/directord/config.yaml ]] || echo "{}" | sudo tee /etc/directord/config.yaml
   - RUN: sudo /usr/bin/directord manage --generate-keys
-  - RUN: sudo /usr/bin/directord-server-systemd
+  - RUN: getent group directord >/dev/null || groupadd -r directord
+  - RUN: sudo /usr/bin/directord-server-systemd --group directord
   - RUN: |-
       sudo python3 <<EOC
       import yaml
@@ -36,7 +37,8 @@ directord_clients:
   - RUN: sudo mv /tmp/client.key-stash /etc/directord/public_keys/client.key
   - ADD: /tmp/server.key /tmp/server.key-stash
   - RUN: sudo mv /tmp/server.key-stash /etc/directord/public_keys/server.key
-  - RUN: sudo /usr/bin/directord-client-systemd
+  - RUN: getent group directord >/dev/null || groupadd -r directord
+  - RUN: sudo /usr/bin/directord-client-systemd --group directord
   - RUN: |-
       sudo python3 <<EOC
       import yaml


### PR DESCRIPTION
When deploying directord via rpm the system should have, and use, a
group to manage the process. this change implements the directord group
within the RPM spec, and ensures that we can define the used group when
rendering / deploying systemd service units via the directord CLI
utilities.

Signed-off-by: Kevin Carter <kecarter@redhat.com>