### PR TITLE
Drop -C from dnf installs

### DIFF
--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -143,7 +143,7 @@ class Component(components.ComponentBase):
             job_stderr.append(stderr)
 
         if to_install:
-            cmd = "dnf -q -y -C install {}".format(" ".join(to_install))
+            cmd = "dnf -q -y install {}".format(" ".join(to_install))
             job_stdout.append(b"=== dnf install ===\n")
             stdout, stderr, outcome = self.run_command(
                 command=cmd, env=cache.get("envs")
@@ -152,7 +152,7 @@ class Component(components.ComponentBase):
             job_stderr.append(stderr)
 
         if to_update:
-            cmd = "dnf -q -y -C update {}".format(" ".join(to_update))
+            cmd = "dnf -q -y update {}".format(" ".join(to_update))
             job_stdout.append(b"=== dnf update ===\n")
             stdout, stderr, outcome = self.run_command(
                 command=cmd, env=cache.get("envs")

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -320,7 +320,7 @@ class TestComponents(unittest.TestCase):
             conn=mock_conn,
             job={"packages": ["kernel", "gcc"]},
         )
-        calls = [call(command="dnf -q -y -C install kernel gcc", env=None)]
+        calls = [call(command="dnf -q -y install kernel gcc", env=None)]
         self.assertEqual(mock_run_command.call_args_list, calls)
         self.assertTrue(outcome)
 
@@ -333,7 +333,7 @@ class TestComponents(unittest.TestCase):
             conn=mock_conn,
             job={"packages": ["kernel", "gcc"]},
         )
-        calls = [call(command="dnf -q -y -C install kernel gcc", env=None)]
+        calls = [call(command="dnf -q -y install kernel gcc", env=None)]
         self.assertEqual(mock_run_command.call_args_list, calls)
         self.assertFalse(outcome)
 
@@ -349,7 +349,7 @@ class TestComponents(unittest.TestCase):
         calls = [
             call(command="dnf clean all", env=None),
             call(command="dnf makecache", env=None),
-            call(command="dnf -q -y -C install kernel gcc", env=None),
+            call(command="dnf -q -y install kernel gcc", env=None),
         ]
         self.assertEqual(mock_run_command.call_args_list, calls)
         self.assertTrue(outcome)
@@ -366,7 +366,7 @@ class TestComponents(unittest.TestCase):
         calls = [
             call(command="dnf list --installed kernel", env=None),
             call(command="dnf list --installed gcc", env=None),
-            call(command="dnf -q -y -C update kernel gcc", env=None),
+            call(command="dnf -q -y update kernel gcc", env=None),
         ]
         self.assertEqual(mock_run_command.call_args_list, calls)
         self.assertTrue(outcome)


### PR DESCRIPTION
Using the systemcache seems to be inconsistent. Let's skip this for now.