### PR TITLE
Remove conn from the components

### DIFF
--- a/components/container_config_data.py
+++ b/components/container_config_data.py
@@ -89,20 +89,15 @@ class Component(components.ComponentBase):
         data.update(vars(self.known_args))
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run cache echo command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
         :type job: Dictionary
         :returns: tuple
         """
-
-        super().client(conn=conn, cache=cache, job=job)
 
         # Set parameters
         config_path = job["config_path"]
@@ -134,7 +129,7 @@ class Component(components.ComponentBase):
             self.log.debug("%s does not exists, skipping step", config_path)
             configs = dict()
 
-        return configs, None, True
+        return configs, None, True, None
 
     def _slurp(self, path):
         """Slurps a file and return its content.

--- a/components/echo.py
+++ b/components/echo.py
@@ -44,12 +44,9 @@ class Component(components.ComponentBase):
         data["echo"] = self.known_args.echo
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run cache echo command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -57,6 +54,5 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         print(job["echo"])
-        return job["echo"], None, True
+        return job["echo"], None, True, None

--- a/components/pod.py
+++ b/components/pod.py
@@ -156,12 +156,9 @@ class Component(components.ComponentBase):
         data["socket_path"] = self.known_args.socket_path
         return data
 
-    def client(self, cache, conn, job):
+    def client(self, cache, job):
         """Run pod command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param command: Work directory path.
         :type command: String
         :param job: Information containing the original job specification.
@@ -169,12 +166,12 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         if not AVAILABLE_PODMAN:
             return (
                 None,
                 "The required podman-py library is not installed",
                 False,
+                None,
             )
         try:
             with PodmanPod(socket=job["socket_path"]) as p:
@@ -184,9 +181,9 @@ class Component(components.ComponentBase):
                     if data:
                         data = json.dumps(data)
                     if status:
-                        return data, None, status
+                        return data, None, status, None
 
-                    return None, data, status
+                    return None, data, status, None
 
                 return (
                     None,
@@ -195,10 +192,11 @@ class Component(components.ComponentBase):
                         "  a function".format(action=job["pod_action"])
                     ),
                     False,
+                    None,
                 )
         except Exception as e:
             self.log.critical(str(e))
-            return None, traceback.format_exc(), False
+            return None, traceback.format_exc(), False, None
 
 
 class PodmanConnect:

--- a/components/secontext.py
+++ b/components/secontext.py
@@ -127,12 +127,9 @@ class Component(components.ComponentBase):
 
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run cache echo command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -140,19 +137,15 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         if not selinux.is_selinux_enabled():
-            return (
-                None,
-                "SELinux is not enabled.",
-                True,
-            )
+            return (None, "SELinux is not enabled.", True, None)
 
         if not AVAILABLE_SELINUX:
             return (
                 None,
                 "The required selinux library is not installed",
                 False,
+                None,
             )
 
         if not AVAILABLE_SEOBJECT:
@@ -160,6 +153,7 @@ class Component(components.ComponentBase):
                 None,
                 "The required seobject library is not installed",
                 False,
+                None,
             )
 
         target = job["target"]
@@ -194,4 +188,4 @@ class Component(components.ComponentBase):
 
             secontext.add(target, setype, ftype, selevel, seuser)
 
-        return job["target"], None, True
+        return job["target"], None, True, None

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -328,21 +328,18 @@ class ComponentBase:
             parser=self.parser, exec_string=exec_string, arg_vars=arg_vars
         )
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Client operation.
 
         Command operations are rendered with cached data from the args dict.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
         :type job: Dictionary
         """
 
-        conn.start_processing()
+        pass
 
     def close(self):
         """Close a component."""

--- a/directord/components/builtin_cache.py
+++ b/directord/components/builtin_cache.py
@@ -67,14 +67,11 @@ class Component(components.ComponentBase):
         data[cache_type] = {key: value}
         return data
 
-    def client(self, command, conn, cache, job):
+    def client(self, command, cache, job):
         """Run cache command operation.
 
         :param command: Work directory path.
         :type command: String
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -82,7 +79,6 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         # Sets the cache type to "args" or "envs"
         cache_type = "{}s".format(command.decode().lower())
 
@@ -98,8 +94,10 @@ class Component(components.ComponentBase):
             value_update=True,
             tag=cache_type,
         )
-        conn.info = "type:{}, value:{}".format(
-            cache_type, job[cache_type]
-        ).encode()
 
-        return "{} added to cache".format(cache_type), None, True
+        return (
+            "{} added to cache".format(cache_type),
+            None,
+            True,
+            "type:{}, value:{}".format(cache_type, job[cache_type]).encode(),
+        )

--- a/directord/components/builtin_cacheevict.py
+++ b/directord/components/builtin_cacheevict.py
@@ -55,12 +55,9 @@ class Component(components.ComponentBase):
         data["cacheevict"] = self.known_args.cacheevict
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run cache evict command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -68,7 +65,6 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         tag = job["cacheevict"]
         if tag == "all":
             evicted = cache.clear()
@@ -76,4 +72,5 @@ class Component(components.ComponentBase):
         else:
             evicted = cache.evict(tag)
             info = "Evicted {} items, tagged {}".format(evicted, tag)
-        return info, None, True
+
+        return info, None, True, None

--- a/directord/components/builtin_cachefile.py
+++ b/directord/components/builtin_cachefile.py
@@ -54,26 +54,22 @@ class Component(components.ComponentBase):
         data["cachefile"] = self.known_args.cachefile
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run cache file operation.
 
         :param cache: Caching object used to template items within a command.
         :type cache: Object
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param job: Information containing the original job specification.
         :type job: Dictionary
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         try:
             with open(job["cachefile"]) as f:
                 cachefile_args = yaml.safe_load(f)
         except Exception as e:
             self.log.critical(str(e))
-            return None, traceback.format_exc(), False
+            return None, traceback.format_exc(), False, None
         else:
             self.set_cache(
                 cache=cache,
@@ -82,4 +78,4 @@ class Component(components.ComponentBase):
                 value_update=True,
                 tag="args",
             )
-            return "Cache file loaded", None, True
+            return "Cache file loaded", None, True, None

--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -70,14 +70,11 @@ class Component(components.ComponentBase):
 
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run file command operation.
 
         Command operations are rendered with cached data from the args dict.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -85,7 +82,6 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         state = job.get("state")
         clear = job.get("clear")
 
@@ -113,7 +109,7 @@ class Component(components.ComponentBase):
         packages = job.get("packages")
 
         if not packages:
-            return None, None, False
+            return None, None, False, None
 
         to_remove = []
         to_install = []
@@ -160,4 +156,4 @@ class Component(components.ComponentBase):
             job_stdout.append(stdout)
             job_stderr.append(stderr)
 
-        return b"".join(job_stdout), b"".join(job_stderr), outcome
+        return b"".join(job_stdout), b"".join(job_stderr), outcome, None

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -56,12 +56,9 @@ class Component(components.ComponentBase):
         data["query"] = self.known_args.query
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run query command operation.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -69,11 +66,10 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         args = cache.get("args")
         if args:
             query = json.dumps(args.get(job["query"]))
         else:
             query = None
 
-        return query, None, True
+        return query, None, True, None

--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -50,14 +50,11 @@ class Component(components.ComponentBase):
 
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run file command operation.
 
         Command operations are rendered with cached data from the args dict.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -65,18 +62,16 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         stdout_arg = job.get("stdout_arg")
         command = self.blueprinter(
             content=job["command"], values=cache.get("args")
         )
         if not command:
-            return None, None, False
+            return None, None, False, None
 
         stdout, stderr, outcome = self.run_command(
             command=command, env=cache.get("envs")
         )
-        conn.info = command.encode()
 
         if stdout_arg and stdout:
             clean_info = stdout.decode().strip()
@@ -88,4 +83,4 @@ class Component(components.ComponentBase):
                 tag="args",
             )
 
-        return stdout, stderr, outcome
+        return stdout, stderr, outcome, command.encode()

--- a/directord/components/builtin_transfer.py
+++ b/directord/components/builtin_transfer.py
@@ -109,7 +109,6 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         file_to = job["file_to"]
         user = job.get("user")
         group = job.get("group")
@@ -133,8 +132,8 @@ class Component(components.ComponentBase):
             if blueprint and not self.file_blueprinter(
                 cache=cache, file_to=file_to
             ):
-                return utils.file_sha256(file_to), None, None
-            return info, None, True
+                return utils.file_sha256(file_to), None, None, None
+            return info, None, True, None
         else:
             self.log.debug(
                 "Requesting transfer of source file:%s", source_file
@@ -169,7 +168,7 @@ class Component(components.ComponentBase):
                         f.write(data)
         except (FileNotFoundError, NotADirectoryError) as e:
             self.log.critical(str(e))
-            return None, traceback.format_exc(), False
+            return None, traceback.format_exc(), False, None
 
         if blueprint and not self.file_blueprinter(
             cache=cache, file_to=file_to
@@ -205,4 +204,4 @@ class Component(components.ComponentBase):
         if mode:
             os.chmod(file_to, mode)
 
-        return utils.file_sha256(file_to), stderr, outcome
+        return utils.file_sha256(file_to), stderr, outcome, None

--- a/directord/components/builtin_workdir.py
+++ b/directord/components/builtin_workdir.py
@@ -61,14 +61,11 @@ class Component(components.ComponentBase):
         data["workdir"] = self.known_args.workdir
         return data
 
-    def client(self, conn, cache, job):
+    def client(self, cache, job):
         """Run file work directory operation.
 
         Command operations are rendered with cached data from the args dict.
 
-        :param conn: Connection object used to store information used in a
-                     return message.
-        :type conn: Object
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.
@@ -76,7 +73,6 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
-        super().client(conn=conn, cache=cache, job=job)
         workdir = self.blueprinter(
             content=job["workdir"], values=cache.get("args")
         )
@@ -123,4 +119,4 @@ class Component(components.ComponentBase):
             if mode:
                 os.chmod(workdir, mode)
 
-            return update_info, stderr, outcome
+            return update_info, stderr, outcome, None

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -171,7 +171,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", True]
+        mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",
@@ -219,7 +219,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", True]
+        mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",
@@ -267,7 +267,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", True]
+        mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",
@@ -305,7 +305,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", True]
+        mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",
@@ -353,7 +353,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", True]
+        mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",
@@ -406,7 +406,7 @@ class TestClient(tests.TestDriverBase):
         mock_diskcache,
         mock_job_executor,
     ):
-        mock_job_executor.return_value = [b"", b"", False]
+        mock_job_executor.return_value = [b"", b"", False, None]
         job_def = {
             "task": "XXX",
             "task_sha256sum": "YYY",

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -89,7 +89,7 @@ class TestComponents(unittest.TestCase):
                 file_to="/test/file",
                 file_sha256sum="YYYYYYYYY",
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -119,7 +119,7 @@ class TestComponents(unittest.TestCase):
                 file_sha256sum="YYYYYYYYY",
                 blueprint=True,
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -144,7 +144,7 @@ class TestComponents(unittest.TestCase):
         mock_file_sha256.return_value = "YYYYYYYYY"
         with patch("builtins.open", unittest.mock.mock_open()):
             job = dict(file_to="/test/file", file_sha256="YYYYYYYYY")
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -170,7 +170,7 @@ class TestComponents(unittest.TestCase):
                 file_sha256="YYYYYYYYY",
                 blueprint=True,
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -212,7 +212,7 @@ class TestComponents(unittest.TestCase):
                 user="nobody",
                 group="nobody",
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -245,7 +245,7 @@ class TestComponents(unittest.TestCase):
                 user=9999,
                 group=9999,
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -277,7 +277,7 @@ class TestComponents(unittest.TestCase):
                 file_sha256="YYYYYYYYY",
                 mode="0o777",
             )
-            stdout, stderr, outcome = self._transfer.client(
+            stdout, stderr, outcome, return_info = self._transfer.client(
                 job_id="XXX",
                 source_file="/orig/file",
                 conn=MagicMock(),
@@ -295,7 +295,7 @@ class TestComponents(unittest.TestCase):
     def test__job_executor_cached(self, mock_log_info, mock_log_debug):
         mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=mock_conn,
             cache=fake_cache,
             info=None,
@@ -314,10 +314,8 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_success(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", True]
-        mock_conn = MagicMock()
-        stdout, stderr, outcome = self._dnf.client(
+        stdout, stderr, outcome, return_info = self._dnf.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"packages": ["kernel", "gcc"]},
         )
         calls = [call(command="dnf -q -y install kernel gcc", env=None)]
@@ -327,10 +325,8 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_fail(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", False]
-        mock_conn = MagicMock()
-        stdout, stderr, outcome = self._dnf.client(
+        stdout, stderr, outcome, return_info = self._dnf.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"packages": ["kernel", "gcc"]},
         )
         calls = [call(command="dnf -q -y install kernel gcc", env=None)]
@@ -340,10 +336,8 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_clear_cache(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", True]
-        mock_conn = MagicMock()
-        stdout, stderr, outcome = self._dnf.client(
+        stdout, stderr, outcome, return_info = self._dnf.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"packages": ["kernel", "gcc"], "clear": True},
         )
         calls = [
@@ -357,10 +351,8 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_latest(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", True]
-        mock_conn = MagicMock()
-        stdout, stderr, outcome = self._dnf.client(
+        stdout, stderr, outcome, return_info = self._dnf.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"packages": ["kernel", "gcc"], "state": "latest"},
         )
         calls = [
@@ -374,10 +366,8 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__dnf_command_absent(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", True]
-        mock_conn = MagicMock()
-        stdout, stderr, outcome = self._dnf.client(
+        stdout, stderr, outcome, return_info = self._dnf.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"packages": ["kernel", "gcc"], "state": "absent"},
         )
         calls = [call(command="dnf -q -y remove kernel gcc", env=None)]
@@ -408,7 +398,7 @@ class TestComponents(unittest.TestCase):
         mock_run_command.return_value = None, None, True
         mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=mock_conn,
             cache=fake_cache,
             info=None,
@@ -439,7 +429,7 @@ class TestComponents(unittest.TestCase):
         mock_file_sha256.return_value = "YYYYYY"
         mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=mock_conn,
             cache=fake_cache,
             info="/source/file1",
@@ -473,7 +463,7 @@ class TestComponents(unittest.TestCase):
         mock_file_sha256.return_value = "YYYYYY"
         mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=mock_conn,
             cache=fake_cache,
             info="/source/file1",
@@ -499,7 +489,7 @@ class TestComponents(unittest.TestCase):
     def test__job_executor_workdir(self, mock_log_debug, mock_makedirs):
         mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=mock_conn,
             cache=fake_cache,
             info=None,
@@ -518,7 +508,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_arg(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -537,7 +527,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_env(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -560,7 +550,7 @@ class TestComponents(unittest.TestCase):
             "builtins.open",
             unittest.mock.mock_open(read_data=tests.TEST_CATALOG.encode()),
         ):
-            stdout, stderr, outcome = self.client._job_executor(
+            stdout, stderr, outcome, return_info = self.client._job_executor(
                 conn=MagicMock(),
                 cache=fake_cache,
                 info=None,
@@ -599,7 +589,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_cachefile_fail(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -618,7 +608,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_cacheevict_all(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -638,7 +628,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_cacheevict_evict(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -658,7 +648,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.debug", autospec=True)
     def test__job_executor_cacheevict_query(self, mock_log_debug):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -679,7 +669,7 @@ class TestComponents(unittest.TestCase):
     @patch("logging.Logger.warning", autospec=True)
     def test__job_executor_unknown(self, mock_log_debug, mock_log_warning):
         fake_cache = tests.FakeCache()
-        stdout, stderr, outcome = self.client._job_executor(
+        stdout, stderr, outcome, return_info = self.client._job_executor(
             conn=MagicMock(),
             cache=fake_cache,
             info=None,
@@ -724,30 +714,24 @@ class TestComponents(unittest.TestCase):
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__run_command(self, mock_run_command):
         mock_run_command.return_value = [b"", b"", True]
-        mock_conn = MagicMock()
         self._run.client(
             cache=tests.FakeCache(),
-            conn=mock_conn,
             job={"command": "command {{ test }} test"},
         )
         mock_run_command.assert_called_with(command="command 1 test", env=None)
-        self.assertEqual(mock_conn.info, b"command 1 test")
 
     @patch("directord.components.ComponentBase.run_command", autospec=True)
     def test__run_command_stdout_args(self, mock_run_command):
         mock_run_command.return_value = [b"testing", b"", True]
-        mock_conn = MagicMock()
         fake_cache = tests.FakeCache()
         self._run.client(
             cache=fake_cache,
-            conn=mock_conn,
             job={
                 "command": "command {{ test }} test",
                 "stdout_arg": "VALUE1",
             },
         )
         mock_run_command.assert_called_with(command="command 1 test", env=None)
-        self.assertEqual(mock_conn.info, b"command 1 test")
         self.assertDictEqual(
             fake_cache.get("args"), {"VALUE1": "testing", "test": 1}
         )
@@ -755,9 +739,7 @@ class TestComponents(unittest.TestCase):
     @patch("os.makedirs", autospec=True)
     def test__run_workdir(self, mock_makedirs):
         fake_cache = tests.FakeCache()
-        self._workdir.client(
-            cache=fake_cache, conn=MagicMock(), job={"workdir": "/test/path"}
-        )
+        self._workdir.client(cache=fake_cache, job={"workdir": "/test/path"})
         mock_makedirs.assert_called_with("/test/path", exist_ok=True)
 
     @patch("os.makedirs", autospec=True)
@@ -765,7 +747,6 @@ class TestComponents(unittest.TestCase):
         fake_cache = tests.FakeCache()
         self._workdir.client(
             cache=fake_cache,
-            conn=MagicMock(),
             job={"workdir": "/test/{{ test }}"},
         )
         mock_makedirs.assert_called_with("/test/1", exist_ok=True)
@@ -773,9 +754,7 @@ class TestComponents(unittest.TestCase):
     @patch("os.makedirs", autospec=True)
     def test__run_workdir_null(self, mock_makedirs):
         fake_cache = tests.FakeCache()
-        self._workdir.client(
-            cache=fake_cache, conn=MagicMock(), job={"workdir": ""}
-        )
+        self._workdir.client(cache=fake_cache, job={"workdir": ""})
 
     @patch("os.chmod", autospec=True)
     @patch("os.makedirs", autospec=True)
@@ -783,7 +762,6 @@ class TestComponents(unittest.TestCase):
         fake_cache = tests.FakeCache()
         self._workdir.client(
             cache=fake_cache,
-            conn=MagicMock(),
             job={"workdir": "/test/path", "mode": "0o777"},
         )
         mock_makedirs.assert_called_with("/test/path", exist_ok=True)
@@ -795,7 +773,6 @@ class TestComponents(unittest.TestCase):
         fake_cache = tests.FakeCache()
         self._workdir.client(
             cache=fake_cache,
-            conn=MagicMock(),
             job={"workdir": "/test/path", "user": 9999, "group": 9999},
         )
         mock_makedirs.assert_called_with("/test/path", exist_ok=True)

--- a/docs/components.md
+++ b/docs/components.md
@@ -218,10 +218,9 @@ class Component(components.ComponentBase):
         data["echo"] = self.known_args.echo
         return data
 
-    def client(self, conn, cache, job):
-        super().client(conn=conn)
+    def client(self, cache, job):
         print(job["echo"])
-        return job["echo"], None, True
+        return job["echo"], None, True, None
 ```
 
 To build a component, only three methods are required. `args`, `server`, `client`.


### PR DESCRIPTION
This change removes all of the connection interactions from the
components and puts them back into the client module. This ensures
better separation between our components and the execution, simplifies
interactions, and will allow us to further pursue async client side
operations.

Signed-off-by: Kevin Carter <kecarter@redhat.com>