### PR TITLE
Re-work query and implement server callbacks

### DIFF
--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -32,7 +32,7 @@ class ComponentBase:
     info = None
     driver = None
     verb = None
-    cooldown = None
+    block_on_task = None
 
     def __init__(self, desc=None):
         """Initialize the component base class.

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -15,6 +15,7 @@
 import json
 
 from directord import components
+from directord import utils
 
 
 class Component(components.ComponentBase):
@@ -69,10 +70,30 @@ class Component(components.ComponentBase):
 
         args = cache.get("args")
         if args:
-            query = json.dumps(args.get(job["query"]))
+            query = args.get(job["query"])
         else:
             query = None
 
-        self.cooldown = 8
+        if query:
+            query_job = job.copy()
+            query_job["task"] = utils.get_uuid()
+            query_job["skip_cache"] = True
+            query_job["extend_args"] = True
+            query_job["verb"] = "ARG"
+            query_job["args"] = {
+                "query": {
+                    self.driver.identity: {query_job.pop("query"): query}
+                }
+            }
+            query_job["parent_async"] = True
+            query_job.pop("parent_sha3_224", None)
+            query_job.pop("parent_id", None)
+            query_job.pop("task_sha3_224", None)
+            query_job["parent_sha3_224"] = utils.object_sha3_224(obj=query_job)
+            query_job["parent_id"] = utils.get_uuid()
+            query_job["task_sha3_224"] = utils.object_sha3_224(query_job)
 
-        return query, None, True, None
+            self.block_on_task = query_job
+            self.log.debug("query job call back [ %s ]", query_job)
+
+        return json.dumps(query), None, True, None


### PR DESCRIPTION
This change re-works the query function to better support the new async
capabilities within Directord. To support this option components have
the ability to generate follow-on tasks which cause an orchestration to
block until the follow-on task has completed.

This change cleans-up the query hacks we had in server and client code
by using new job generation instead of attempting to run through a
series of string matching tomfoolery.

Signed-off-by: Kevin Carter <kecarter@redhat.com>