### PR TITLE
add parent async bypass

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,6 +62,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-functional.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
       - name: Upload build Log artifacts on failure
@@ -104,6 +106,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-functional-async.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
       - name: Execute functional async-race-condition check
@@ -115,15 +119,21 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-functional-async-race.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
       - name: Execute functional async-time check
         run: |
           cd /opt/directord/share/directord/orchestrations
-          timeout 40 sudo /opt/directord/bin/directord \
+          if ! timeout 40 sudo /opt/directord/bin/directord \
                           orchestrate \
                           functional-tests-async-time.yaml \
-                          --poll &> /tmp/directord-functional-async-time.log
+                          --poll &> /tmp/directord-functional-async-time.log; then
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
+            exit 1
+          fi
       - name: Upload build Log artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v2
@@ -164,6 +174,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-podman.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
       - name: Execute pod play check
@@ -175,6 +187,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-create.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
           sleep 10
@@ -191,6 +205,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-command.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
           if ! JOBS=$(sudo /opt/directord/bin/directord \
@@ -200,6 +216,8 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-kill.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
           if ! JOBS=$(sudo /opt/directord/bin/directord \
@@ -209,12 +227,16 @@ jobs:
                       --poll \
                       --check); then
             echo ${JOBS} | xargs -n 1 sudo /opt/directord/bin/directord manage --job-info &> /tmp/directord-rm.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
           sleep 10
           if sudo podman pod exists directord-test-pod; then
             echo -e "FAILURE - [ directord-test-pod ] was still active on the system"
             sudo /opt/directord/bin/directord manage --list-jobs | awk '/([aA-zZ]|[0-9])-/ {print $1}' | xargs -n 1 -i sudo /opt/directord/bin/directord manage --job-info {} &> /tmp/directord-failure.log
+            journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+            journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
             exit 1
           fi
       - name: Upload build Log artifacts on failure

--- a/directord/client.py
+++ b/directord/client.py
@@ -388,7 +388,7 @@ class Client(interface.Interface):
                 block_on_task = True
                 with self.timeout(
                     time=240,
-                    job_id=component.block_on_task["task"],
+                    job_id=component.block_on_task["job_id"],
                 ):
                     while block_on_task:
                         with diskcache.Cache(
@@ -397,7 +397,7 @@ class Client(interface.Interface):
                             disk=diskcache.JSONDisk,
                         ) as cache:
                             if cache.get(
-                                component.block_on_task["task_sha3_224"]
+                                component.block_on_task["job_sha3_224"]
                             ) in [
                                 self.driver.job_end.decode(),
                                 self.driver.job_failed.decode(),
@@ -413,7 +413,7 @@ class Client(interface.Interface):
                     else:
                         self.log.debug(
                             "Task [ %s ] callback complete",
-                            component.block_on_task["task"],
+                            component.block_on_task["job_id"],
                         )
 
             if parent_lock:
@@ -697,9 +697,11 @@ class Client(interface.Interface):
                         _,
                     ) = self.driver.socket_recv(socket=self.bind_job)
                     job = json.loads(data.decode())
-                    job["job_id"] = job_id = job.get("task", utils.get_uuid())
+                    job["job_id"] = job_id = job.get(
+                        "job_id", utils.get_uuid()
+                    )
                     job["job_sha3_224"] = job_sha3_224 = job.get(
-                        "task_sha3_224", utils.object_sha3_224(job)
+                        "job_sha3_224", utils.object_sha3_224(job)
                     )
                     self.driver.socket_send(
                         socket=self.bind_job,

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -76,7 +76,7 @@ class Component(components.ComponentBase):
 
         if query:
             query_job = job.copy()
-            query_job["task"] = utils.get_uuid()
+            query_job["job_id"] = utils.get_uuid()
             query_job["skip_cache"] = True
             query_job["extend_args"] = True
             query_job["verb"] = "ARG"
@@ -88,10 +88,10 @@ class Component(components.ComponentBase):
             query_job["parent_async_bypass"] = True
             query_job.pop("parent_sha3_224", None)
             query_job.pop("parent_id", None)
-            query_job.pop("task_sha3_224", None)
+            query_job.pop("job_sha3_224", None)
             query_job["parent_sha3_224"] = utils.object_sha3_224(obj=query_job)
             query_job["parent_id"] = utils.get_uuid()
-            query_job["task_sha3_224"] = utils.object_sha3_224(query_job)
+            query_job["job_sha3_224"] = utils.object_sha3_224(query_job)
 
             self.block_on_task = query_job
             self.log.debug("query job call back [ %s ]", query_job)

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -76,7 +76,6 @@ class Component(components.ComponentBase):
 
         if query:
             query_job = job.copy()
-            query_job["job_id"] = utils.get_uuid()
             query_job["skip_cache"] = True
             query_job["extend_args"] = True
             query_job["verb"] = "ARG"
@@ -90,8 +89,9 @@ class Component(components.ComponentBase):
             query_job.pop("parent_id", None)
             query_job.pop("job_sha3_224", None)
             query_job["parent_sha3_224"] = utils.object_sha3_224(obj=query_job)
-            query_job["parent_id"] = utils.get_uuid()
             query_job["job_sha3_224"] = utils.object_sha3_224(query_job)
+            query_job["parent_id"] = utils.get_uuid()
+            query_job["job_id"] = utils.get_uuid()
 
             self.block_on_task = query_job
             self.log.debug("query job call back [ %s ]", query_job)

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -85,7 +85,7 @@ class Component(components.ComponentBase):
                     self.driver.identity: {query_job.pop("query"): query}
                 }
             }
-            query_job["parent_async"] = True
+            query_job["parent_async_bypass"] = True
             query_job.pop("parent_sha3_224", None)
             query_job.pop("parent_id", None)
             query_job.pop("task_sha3_224", None)

--- a/directord/meta.py
+++ b/directord/meta.py
@@ -12,7 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __author__ = "Kevin Carter"
 __email__ = "kevin@cloudnull.com"
 __driver_options__ = ["zmq"]

--- a/directord/mixin.py
+++ b/directord/mixin.py
@@ -116,7 +116,7 @@ class Mixin:
 
         data["timeout"] = getattr(component.known_args, "timeout", 600)
         data["run_once"] = getattr(component.known_args, "run_once", False)
-        data["task_sha3_224"] = utils.object_sha3_224(obj=data)
+        data["job_sha3_224"] = utils.object_sha3_224(obj=data)
         data["return_raw"] = return_raw
         data["skip_cache"] = ignore_cache or getattr(
             component.known_args, "skip_cache", False
@@ -233,7 +233,7 @@ class Mixin:
                         job["parent_sha3_224"],
                         item["verb"],
                         exec_str,
-                        item["task_sha3_224"],
+                        item["job_sha3_224"],
                     ]
                 )
                 return_data.append(tabulated_data)

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -164,8 +164,7 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_sha3_224": "YYY",
             "skip_cache": True,
             "command": "RUN",
             "job_id": "XXX",
@@ -212,8 +211,8 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
             "ignore_cache": True,
             "command": "RUN",
             "job_id": "XXX",
@@ -260,8 +259,8 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
             "parent_id": "ZZZ",
             "command": "RUN",
         }
@@ -298,8 +297,8 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
             "command": "RUN",
             "job_id": "XXX",
             "job_sha3_224": "YYY",
@@ -346,8 +345,8 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", True, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
             "command": "RUN",
             "parent_id": "ZZZ",
             "job_id": "XXX",
@@ -396,8 +395,8 @@ class TestClient(tests.TestDriverBase):
     ):
         mock_job_executor.return_value = [b"", b"", False, None]
         job_def = {
-            "task": "XXX",
-            "task_sha3_224": "YYY",
+            "job_id": "XXX",
+            "job_sha3_224": "YYY",
             "command": "RUN",
             "job_id": "XXX",
             "job_sha3_224": "YYY",

--- a/directord/tests/test_mixin.py
+++ b/directord/tests/test_mixin.py
@@ -95,7 +95,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -115,7 +115,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test_target"],
@@ -136,7 +136,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
                     "return_raw": False,
                     "skip_cache": True,
                 }
@@ -156,7 +156,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "restrict": "Restrictedsha3_224",
@@ -177,7 +177,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "long '{{ jinja }}' quoted string string",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
+                    "job_sha3_224": "df28f8fb5a4c06c52a3bf4f41035e71d1c641736ef424b3582eb30f2",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "parent_id": "ParentID",
@@ -197,7 +197,7 @@ class TestMixin(tests.TestConnectionBase):
             "blueprint": False,
             "timeout": 600,
             "run_once": False,
-            "task_sha3_224": "de85bef754e1c7652d64cfd19f0a731e70d9bdc42a6698fabfd0f3ac",  # noqa
+            "job_sha3_224": "de85bef754e1c7652d64cfd19f0a731e70d9bdc42a6698fabfd0f3ac",  # noqa
             "return_raw": False,
             "skip_cache": False,
         }
@@ -218,7 +218,7 @@ class TestMixin(tests.TestConnectionBase):
             "blueprint": False,
             "timeout": 600,
             "run_once": False,
-            "task_sha3_224": "9420176ba6b63667ffdd0c2e51d896e74a9c8fe100a168bd6086db38",  # noqa
+            "job_sha3_224": "9420176ba6b63667ffdd0c2e51d896e74a9c8fe100a168bd6086db38",  # noqa
             "return_raw": False,
             "skip_cache": False,
         }
@@ -233,7 +233,7 @@ class TestMixin(tests.TestConnectionBase):
             "args": {"key": "value"},
             "timeout": 600,
             "run_once": False,
-            "task_sha3_224": "a5d63364114e96a96e5be4261f31a9bc0a45ecd2d5edba11336dd896",  # noqa
+            "job_sha3_224": "a5d63364114e96a96e5be4261f31a9bc0a45ecd2d5edba11336dd896",  # noqa
             "return_raw": False,
             "skip_cache": False,
         }
@@ -246,7 +246,7 @@ class TestMixin(tests.TestConnectionBase):
             "envs": {"key": "value"},
             "timeout": 600,
             "run_once": False,
-            "task_sha3_224": "adb3790c327b3b2fd3c438c900ab8a2d6260e1d812eb22cdd056dfc9",  # noqa
+            "job_sha3_224": "adb3790c327b3b2fd3c438c900ab8a2d6260e1d812eb22cdd056dfc9",  # noqa
             "return_raw": False,
             "skip_cache": False,
         }
@@ -265,7 +265,7 @@ class TestMixin(tests.TestConnectionBase):
                     "workdir": "/test/path",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "b899de26c8055243a43cc0c28d5a689a8ce6510bfcb420397e673a5f",  # noqa
+                    "job_sha3_224": "b899de26c8055243a43cc0c28d5a689a8ce6510bfcb420397e673a5f",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -284,7 +284,7 @@ class TestMixin(tests.TestConnectionBase):
                     "cachefile": "/test/path",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "dfce171945da1e2079b3ac4a7066eba6efd4880cadd10a649f95a1b4",  # noqa
+                    "job_sha3_224": "dfce171945da1e2079b3ac4a7066eba6efd4880cadd10a649f95a1b4",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -301,7 +301,7 @@ class TestMixin(tests.TestConnectionBase):
                     "cacheevict": "test",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "06460bd89ead48bd50398d0f9f1cd058c169492f88cf915db94eca7f",  # noqa
+                    "job_sha3_224": "06460bd89ead48bd50398d0f9f1cd058c169492f88cf915db94eca7f",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -318,7 +318,7 @@ class TestMixin(tests.TestConnectionBase):
                     "query": "test",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "6a3389639ebec5f7bcae998f73545fb9efb9cc975a38606168b6ceb9",  # noqa
+                    "job_sha3_224": "6a3389639ebec5f7bcae998f73545fb9efb9cc975a38606168b6ceb9",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }
@@ -347,7 +347,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -386,7 +386,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": [
@@ -422,7 +422,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -457,7 +457,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": False,
                     "skip_cache": True,
                     "targets": ["test1", "test2", "test3"],
@@ -491,7 +491,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": True,
                     "skip_cache": False,
                     "targets": ["test1", "test2", "test3"],
@@ -559,7 +559,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command3",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
+                    "job_sha3_224": "f23220892ee6f80b9934a5b014a808e21904862d1c3eba3c470991dd",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test"],
@@ -590,7 +590,7 @@ class TestMixin(tests.TestConnectionBase):
                     "command": "command 1",
                     "timeout": 600,
                     "run_once": False,
-                    "task_sha3_224": "36796bb09a3838fa2c8bcb802eb9494546289a6fd6ed988579524ee1",  # noqa
+                    "job_sha3_224": "36796bb09a3838fa2c8bcb802eb9494546289a6fd6ed988579524ee1",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                     "targets": ["test"],

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -62,7 +62,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -86,7 +86,7 @@ class TestServer(tests.TestDriverBase):
                 "PROCESSING": "\x06",
                 "STDERR": {},
                 "STDOUT": {},
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "TRANSFERS": [],
                 "VERB": "RUN",
                 "_createtime": 1,
@@ -103,7 +103,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -128,7 +128,7 @@ class TestServer(tests.TestDriverBase):
                 "PROCESSING": "\x06",
                 "STDERR": {},
                 "STDOUT": {"test-node": "stdout"},
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "TRANSFERS": [],
                 "VERB": "RUN",
                 "_createtime": 1,
@@ -145,7 +145,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -170,7 +170,7 @@ class TestServer(tests.TestDriverBase):
                 "PROCESSING": "\x06",
                 "STDERR": {"test-node": "stderr"},
                 "STDOUT": {},
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "TRANSFERS": [],
                 "VERB": "RUN",
                 "_createtime": 1,
@@ -187,7 +187,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -211,7 +211,7 @@ class TestServer(tests.TestDriverBase):
                 "PROCESSING": "\x16",
                 "STDERR": {},
                 "STDOUT": {},
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "TRANSFERS": [],
                 "VERB": "RUN",
                 "_createtime": 1,
@@ -228,7 +228,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -254,7 +254,7 @@ class TestServer(tests.TestDriverBase):
                 "STDERR": {},
                 "STDOUT": {},
                 "SUCCESS": ["test-node"],
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "ROUNDTRIP_TIME": ANY,
                 "TRANSFERS": [],
                 "VERB": "RUN",
@@ -272,7 +272,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -298,7 +298,7 @@ class TestServer(tests.TestDriverBase):
                 "STDERR": {},
                 "STDOUT": {},
                 "SUCCESS": ["test-node"],
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "ROUNDTRIP_TIME": ANY,
                 "TRANSFERS": [],
                 "VERB": "RUN",
@@ -316,7 +316,7 @@ class TestServer(tests.TestDriverBase):
                 "NODES": ["test-node"],
                 "VERB": "RUN",
                 "TRANSFERS": list(),
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "JOB_DEFINITION": {},
                 "PARENT_JOB_ID": "ZZZ",
                 "_createtime": 1,
@@ -342,7 +342,7 @@ class TestServer(tests.TestDriverBase):
                 "STDERR": {},
                 "STDOUT": {},
                 "FAILED": ["test-node"],
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "ROUNDTRIP_TIME": ANY,
                 "TRANSFERS": [],
                 "VERB": "RUN",
@@ -369,7 +369,7 @@ class TestServer(tests.TestDriverBase):
             task="XXX",
             job_item={
                 "verb": "TEST",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "parent_id": "ZZZ",
             },
             targets=[b"test-node1", b"test-node2"],
@@ -381,14 +381,14 @@ class TestServer(tests.TestDriverBase):
                 "INFO": {},
                 "JOB_DEFINITION": {
                     "parent_id": "ZZZ",
-                    "task_sha3_224": "YYY",
+                    "job_sha3_224": "YYY",
                     "verb": "TEST",
                 },
                 "NODES": ["test-node1", "test-node2"],
                 "PARENT_JOB_ID": "ZZZ",
                 "STDERR": {},
                 "STDOUT": {},
-                "TASK_SHA3_224": "YYY",
+                "JOB_SHA3_224": "YYY",
                 "TRANSFERS": [],
                 "VERB": "TEST",
                 "_createtime": ANY,
@@ -402,7 +402,7 @@ class TestServer(tests.TestDriverBase):
             task="XXX",
             job_item={
                 "verb": "TEST",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "parent_id": "ZZZ",
             },
             targets=[b"test-node1", b"test-node2"],
@@ -428,9 +428,9 @@ class TestServer(tests.TestDriverBase):
             {
                 "verb": "RUN",
                 "restrict": "12345",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "targets": ["test-node1", "test-node2"],
-                "task": "XXX",
+                "job_id": "XXX",
             }
         ]
         self.server.job_queue = mock_queue
@@ -444,9 +444,9 @@ class TestServer(tests.TestDriverBase):
         mock_queue.get_nowait.side_effect = [
             {
                 "verb": "RUN",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "targets": ["test-node1", "test-node2"],
-                "task": "XXX",
+                "job_id": "XXX",
             }
         ]
         self.server.job_queue = mock_queue
@@ -461,9 +461,9 @@ class TestServer(tests.TestDriverBase):
         mock_queue.get_nowait.side_effect = [
             {
                 "verb": "RUN",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "targets": ["test-node1", "test-node2"],
-                "task": "XXX",
+                "job_id": "XXX",
             }
         ]
         self.server.job_queue = mock_queue
@@ -645,9 +645,9 @@ class TestServer(tests.TestDriverBase):
                     {
                         "verb": "RUN",
                         "restrict": "12345",
-                        "task_sha3_224": "YYY",
+                        "job_sha3_224": "YYY",
                         "targets": ["test-node1", "test-node2"],
-                        "task": "XXX",
+                        "job_id": "XXX",
                         "query": "key",
                     }
                 ).encode(),
@@ -793,9 +793,9 @@ class TestServer(tests.TestDriverBase):
             {
                 "verb": "RUN",
                 "restrict": "12345",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "targets": ["test-node1", "test-node2"],
-                "task": "XXX",
+                "job_id": "XXX",
                 "query": "key",
             }
         ).encode()
@@ -821,9 +821,9 @@ class TestServer(tests.TestDriverBase):
             {
                 "verb": "RUN",
                 "restrict": "12345",
-                "task_sha3_224": "YYY",
+                "job_sha3_224": "YYY",
                 "targets": ["test-node1", "test-node2"],
-                "task": "XXX",
+                "job_id": "XXX",
                 "return_raw": True,
             }
         ).encode()

--- a/docs/components.md
+++ b/docs/components.md
@@ -297,12 +297,12 @@ STDOUT                df.next-c0.localdomain = true
 STDERR                df.next-c0.localdomain =
 NODES                 df.next-c0.localdomain
 VERB                  ECHO
-TASK_SHA3_224         86823a46fb4af75c9f93c8bedb301dfa8968321a
+JOB_SHA3_224          86823a46fb4af75c9f93c8bedb301dfa8968321a
 JOB_DEFINITION        verb = ECHO
                       echo = true
                       timeout = 600
-                      task_sha3_224 = 86823a46fb4af75c9f93c8bedb301dfa8968321a
-                      task = 09a0d4aa-ff84-40e4-a7e2-88be8dff841a
+                      job_sha3_224 = 86823a46fb4af75c9f93c8bedb301dfa8968321a
+                      job_id = 09a0d4aa-ff84-40e4-a7e2-88be8dff841a
                       parent_id = 09a0d4aa-ff84-40e4-a7e2-88be8dff841a
 PARENT_JOB_ID         09a0d4aa-ff84-40e4-a7e2-88be8dff841a
 PROCESSING
@@ -333,3 +333,19 @@ conversion method `options_converter`, which will allow developers to create
 new Directord components with ease. An example of a converted module can be
 seen in the `container_config_data` component and found
 [here](https://github.com/cloudnull/directord/blob/main/components/container_config_data.py).
+
+#### Job specification
+
+| Key                   | Value                                 |
+| --------------------- | --------------------------------------|
+| `${COMPONENT_OPTS}`   | **Component specific options**        |
+| `verb`                | **Component verb**                    |
+| `timeout`             | **Time value in seconds**             |
+| `skip_cache`          | **Boolean, skips local cache checks** |
+| `targets`             | **Array of targets**                  |
+| `job_id`              | **UUID**                              |
+| `job_sha3_224`        | **Job SHA in SHA3 224**               |
+| `extend_args`         | **Boolean**                           |
+| `parent_async_bypass` | **Boolean**                           |
+| `parent_sha3_224`     | **Parent SHA in SHA3 224**            |
+| `parent_id`           | **UUID**                              |

--- a/orchestrations/functional-tests-async-race.yaml
+++ b/orchestrations/functional-tests-async-race.yaml
@@ -28,6 +28,10 @@
 
   - RUN: --skip-cache rmdir /tmp/test/mode0
 
+  # Ensure query works in async
+  - RUN: --stdout-arg query_test_arg0 hostname -f
+  - QUERY: query_test_arg0
+  - RUN: echo "{{ query }}" | tee /tmp/test/test-query0
 
 - async: true
   jobs:
@@ -55,6 +59,10 @@
 
   - RUN: --skip-cache rmdir /tmp/test/mode1
 
+  # Ensure query works in async
+  - RUN: --stdout-arg query_test_arg1 hostname -f
+  - QUERY: query_test_arg1
+  - RUN: echo "{{ query }}" | tee /tmp/test/test-query1
 
 - async: true
   jobs:
@@ -81,3 +89,8 @@
   - RUN: --skip-cache stat /tmp/test/mode2 | grep Uid | grep 0777
 
   - RUN: --skip-cache rmdir /tmp/test/mode2
+
+  # Ensure query works in async
+  - RUN: --stdout-arg query_test_arg2 hostname -f
+  - QUERY: query_test_arg2
+  - RUN: echo "{{ query }}" | tee /tmp/test/test-query2


### PR DESCRIPTION
When running call-back jobs from a given parent, the call-back task
should have the ability to execute in-front of any other blocking tasks.
This change provides the ability to bypass the queues and run in a new
daemonic thread.

Signed-off-by: Kevin Carter <kecarter@redhat.com>