### PR TITLE
Use comment parent ids when running call back jobs

### DIFF
--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -20,6 +20,7 @@ from directord import components
 class Component(components.ComponentBase):
     def __init__(self):
         super().__init__(desc="Process query_wait commands")
+        self.cacheable = False
 
     def args(self):
         """Set default arguments for a component."""

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -32,7 +32,7 @@ class ComponentBase:
     info = None
     driver = None
     verb = None
-    block_on_task = None
+    block_on_tasks = None
 
     def __init__(self, desc=None):
         """Initialize the component base class.

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -58,14 +58,6 @@ class Component(components.ComponentBase):
         data["query"] = self.known_args.query
         return data
 
-    @staticmethod
-    def hash_job(new_job):
-        new_job["parent_sha3_224"] = utils.object_sha3_224(obj=new_job)
-        new_job["job_sha3_224"] = utils.object_sha3_224(obj=new_job)
-        new_job["parent_id"] = utils.get_uuid()
-        new_job["job_id"] = utils.get_uuid()
-        return new_job
-
     def client(self, cache, job):
         """Run query command operation.
 
@@ -84,7 +76,12 @@ class Component(components.ComponentBase):
 
         if query:
             query_job = job.copy()
+            targets = query_job.pop("targets", list())
             query_item = query_job.pop("query")
+            query_job.pop("parent_sha3_224", None)
+            query_job.pop("parent_id", None)
+            query_job.pop("job_sha3_224", None)
+            query_job.pop("job_id", None)
             query_job["skip_cache"] = True
             query_job["extend_args"] = True
             query_job["verb"] = "ARG"
@@ -92,21 +89,24 @@ class Component(components.ComponentBase):
                 "query": {self.driver.identity: {query_item: query}}
             }
             query_job["parent_async_bypass"] = True
-            query_job.pop("parent_sha3_224", None)
-            query_job.pop("parent_id", None)
-            query_job.pop("job_sha3_224", None)
-            query_job = self.hash_job(new_job=query_job)
-            block_task = query_job["new_task"] = dict(
+            query_job["job_sha3_224"] = utils.object_sha3_224(obj=query_job)
+
+            block_task = dict(
                 skip_cache=True,
                 verb="QUERY_WAIT",
                 item=query_item,
-                identity=job.get("targets", list()),
+                identity=targets,
+                targets=targets,
                 parent_async_bypass=True,
                 query_timeout=600,
             )
-            block_task["targets"] = block_task["identity"]
-            block_task = self.hash_job(new_job=block_task)
-            self.block_on_task = query_job
-            self.log.debug("query job call back [ %s ]", query_job)
+            block_task["job_sha3_224"] = utils.object_sha3_224(obj=query_job)
+            query_job["parent_sha3_224"] = block_task[
+                "parent_sha3_224"
+            ] = utils.object_sha3_224(obj=query_job)
+            query_job["parent_id"] = block_task["parent_id"] = utils.get_uuid()
+
+            self.block_on_tasks = [query_job, block_task]
+            self.log.debug("query job call back [ %s ]", self.block_on_tasks)
 
         return json.dumps(query), None, True, None


### PR DESCRIPTION
Call back jobs is now an array of jobs

This gives component developers the ability to run multiple jobs as a call back as needed while also ensuring the order of execution is correct by blocking on the last job within the array.

Signed-off-by: Kevin Carter <kecarter@redhat.com>