### PR TITLE
Ensure query always runs follow-on tasks

### DIFF
--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -1,0 +1,91 @@
+#   Copyright Peznauts <kevin@cloudnull.com>. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import time
+
+from directord import components
+
+
+class Component(components.ComponentBase):
+    def __init__(self):
+        super().__init__(desc="Process query_wait commands")
+        self.cacheable = False
+
+    def args(self):
+        """Set default arguments for a component."""
+
+        super().args()
+        self.parser.add_argument(
+            "sha",
+            help=("job sha to be completed."),
+        )
+        self.parser.add_argument(
+            "--job-timeout",
+            help=(
+                "Wait for %(default)s seconds for a given item to be present"
+                " in cache."
+            ),
+            default=600,
+            type=int,
+        )
+
+    def server(self, exec_array, data, arg_vars):
+        """Return data from formatted cacheevict action.
+
+        :param exec_array: Input array from action
+        :type exec_array: List
+        :param data: Formatted data hash
+        :type data: Dictionary
+        :param arg_vars: Pre-Formatted arguments
+        :type arg_vars: Dictionary
+        :returns: Dictionary
+        """
+
+        super().server(exec_array=exec_array, data=data, arg_vars=arg_vars)
+        data["job_sha"] = self.known_args.sha
+        data["job_timeout"] = self.known_args.job_timeout
+        return data
+
+    def client(self, cache, job):
+        """Run cache query_wait command operation.
+
+        :param cache: Caching object used to template items within a command.
+        :type cache: Object
+        :param job: Information containing the original job specification.
+        :type job: Dictionary
+        :returns: tuple
+        """
+
+        start_time = time.time()
+        while (time.time() - start_time) < job["job_timeout"]:
+            if cache.get(job["sha"]) in [
+                self.driver.job_end.decode(),
+                self.driver.job_failed.decode(),
+                self.driver.nullbyte.decode(),
+            ]:
+                return (
+                    "Job completed",
+                    None,
+                    True,
+                    "Job {} found complete".format(job["sha"]),
+                )
+
+            time.sleep(1)
+
+        return (
+            None,
+            "Timeout after {} seconds".format(job["job_timeout"]),
+            False,
+            "Job {} was never found in a completed state".format(job["sha"]),
+        )

--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -107,17 +107,29 @@ class Component(components.ComponentBase):
         if success:
             cache_value = value
 
-        self.set_cache(
-            cache=cache,
-            key=cache_type,
-            value=cache_value,
-            value_update=True,
-            tag=cache_type,
-            extend=job.get("extend_args", False),
-        )
-        return (
-            "{} added to cache".format(cache_type),
-            None,
-            True,
-            "type:{}, value:{}".format(cache_type, job[cache_type]).encode(),
-        )
+        if cache_value:
+            self.set_cache(
+                cache=cache,
+                key=cache_type,
+                value=cache_value,
+                value_update=True,
+                tag=cache_type,
+                extend=job.get("extend_args", False),
+            )
+            return (
+                "{} added to cache".format(cache_type),
+                None,
+                True,
+                "type:{}, value:{}".format(
+                    cache_type, job[cache_type]
+                ).encode(),
+            )
+        else:
+            return (
+                "Nothing added to cache. {} had no value".format(cache_type),
+                None,
+                True,
+                "type:{}, value:{}".format(
+                    cache_type, job[cache_type]
+                ).encode(),
+            )

--- a/docs/components.md
+++ b/docs/components.md
@@ -228,10 +228,24 @@ Block client task execution until a specific item is present in the remote query
 
 * `--query-timeout` **INTEGER** Wait time for an item to be present in the query cache.
 
+* `--identity` **STRING** sets a specific identity when searching for cache entries.
+  This can be used multiple times.
+
 > The lookup will search for a **KEY** within the query cache using the input string by
   flattening the identity cache blobs.
 
 > While blocking, the loop will wait 1 second between check intervals.
+
+##### `JOB_WAIT`
+
+Syntax: `STRING`
+
+Block client task execution until a specific job has entered a completed state.
+
+* `--job-timeout` **INTEGER** Wait time for an item to be present in the query cache.
+
+> `JOB_WAIT` requires the job SHA to block. This is most useful for component developers
+  using callback jobs.
 
 ### User defined Components
 


### PR DESCRIPTION
New component JOB_WAIT has been added. This will allow an orchestration
to block on a particular job SHA to be in a completed state.

Signed-off-by: Kevin Carter <kecarter@redhat.com>