### PR TITLE
Add lock to DNF

### DIFF
--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -20,6 +20,7 @@ class Component(components.ComponentBase):
         """Initialize the component cache class."""
 
         super().__init__(desc="Manage packages with dnf")
+        self.requires_lock = True
 
     def args(self):
         """Set default arguments for a component."""


### PR DESCRIPTION
While dnf has locking, it's not exactly async friendly so let's add a
lock requirement to the DNF component.