### PR TITLE
Add debug for client call

### DIFF
--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -91,6 +91,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         # Sets the cache type to "args" or "envs"
         cache_type = "{}s".format(self.command.decode().lower())
 

--- a/directord/components/builtin_cacheevict.py
+++ b/directord/components/builtin_cacheevict.py
@@ -65,6 +65,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         tag = job["cacheevict"]
         if tag.lower() == "all":
             evicted = cache.clear()

--- a/directord/components/builtin_cachefile.py
+++ b/directord/components/builtin_cachefile.py
@@ -65,6 +65,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         try:
             with open(job["cachefile"]) as f:
                 cachefile_args = yaml.safe_load(f)

--- a/directord/components/builtin_copy.py
+++ b/directord/components/builtin_copy.py
@@ -117,6 +117,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         with Transfer(driver=self.driver) as bind_transfer:
             return self._client(
                 cache, job, self.info, self.driver, bind_transfer

--- a/directord/components/builtin_dnf.py
+++ b/directord/components/builtin_dnf.py
@@ -83,6 +83,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         state = job.get("state")
         clear = job.get("clear")
 

--- a/directord/components/builtin_query.py
+++ b/directord/components/builtin_query.py
@@ -68,6 +68,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         args = cache.get("args")
         if args:
             query = args.get(job["query"])

--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -67,6 +67,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         stdout_arg = job.get("stdout_arg")
         success, command = self.blueprinter(
             content=job["command"],

--- a/directord/components/builtin_workdir.py
+++ b/directord/components/builtin_workdir.py
@@ -73,6 +73,7 @@ class Component(components.ComponentBase):
         :returns: tuple
         """
 
+        self.log.debug("client(): job: %s, cache: %s", job, cache)
         success, workdir = self.blueprinter(
             content=job["workdir"],
             values=cache.get("args"),


### PR DESCRIPTION
To help determine job/cache issues, it would be beneficial to have a
debug entry at the start of the component client() call.