### PR TITLE
Fix set_cache to use get and not pop

### DIFF
--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -274,7 +274,7 @@ class ComponentBase:
         """
 
         if value_update:
-            orig = cache.pop(key, default=dict())
+            orig = cache.get(key, default=dict())
             value = utils.merge_dict(orig, value, extend=extend)
         else:
             try:

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -171,7 +171,11 @@ class FakeCache:
     def iterkeys(self):
         return list(self.cache.keys())
 
-    def get(self, key):
+    def get(self, key, **kwargs):
+        if key not in self.cache:
+            if "default" in kwargs:
+                return kwargs["default"]
+
         return self.cache.get(key)
 
     def pop(self, key, **kwargs):


### PR DESCRIPTION
There can be a race condition when updating a value because pop would
remove it from the cache for a period of time. Switching to get will
prevent the value from completely disappearing if others attempt to
fetch it while it's being updated. There is still a race if two tasks
are running in parallel that expect a value to be provided by one of the
tasks for the other.