### PR TITLE
use callback task to set stdout-args

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -202,14 +202,14 @@ jobs:
       - name: Execute functional podman install
         run: |
           cd /opt/directord/share/directord/orchestrations
-          sudo timeout 120 /opt/directord/bin/directord \
+          sudo timeout 240 /opt/directord/bin/directord \
                                               orchestrate \
                                               podman.yaml \
                                               --poll \
                                               --check
       - name: Execute pod play check
         run: |
-          sudo timeout 120 /opt/directord/bin/directord \
+          sudo timeout 240 /opt/directord/bin/directord \
                                               exec \
                                               --verb POD \
                                               '--play /opt/directord/share/directord/pods/pod-directord-test-pod.yaml' \
@@ -221,19 +221,19 @@ jobs:
             sudo podman pod list &> /tmp/directord-podman-list.log
             exit 1
           fi
-          sudo timeout 120 /opt/directord/bin/directord \
+          sudo timeout 240 /opt/directord/bin/directord \
                                               exec \
                                               --verb POD \
                                               '--exec-run directord-test-pod-directord-server-1 --env TEST0=hello,TEST1=world --command "/usr/bin/echo ${TEST0} ${TEST1}"' \
                                               --poll \
                                               --check
-          sudo timeout 120 /opt/directord/bin/directord \
+          sudo timeout 240 /opt/directord/bin/directord \
                                               exec \
                                               --verb POD \
                                               '--signal SIGKILL --kill directord-test-pod' \
                                               --poll \
                                               --check
-          sudo timeout 120 /opt/directord/bin/directord \
+          sudo timeout 240 /opt/directord/bin/directord \
                                               exec \
                                               --verb POD \
                                               '--force --rm directord-test-pod' \

--- a/directord/components/builtin_cacheevict.py
+++ b/directord/components/builtin_cacheevict.py
@@ -24,6 +24,7 @@ class Component(components.ComponentBase):
 
         super().__init__(desc="Process cacheevict commands")
         self.cacheable = False
+        self.requires_lock = True
 
     def args(self):
         """Set default arguments for a component."""

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -770,9 +770,6 @@ class TestComponents(unittest.TestCase):
         mock_run_command.assert_called_with(
             command="command 1 test", env=None, no_block=None
         )
-        self.assertDictEqual(
-            fake_cache.get("args"), {"VALUE1": "testing", "test": 1}
-        )
 
     @patch("os.makedirs", autospec=True)
     def test__run_workdir(self, mock_makedirs):


### PR DESCRIPTION
When executing RUN with stdout args we should set the cache using the
ARG component, which provides a thread safe interface. This change
removes the RUN commands direct cache access and replaces it with a
callback.

Signed-off-by: Kevin Carter <kecarter@redhat.com>