### PR TITLE
ensure that the stdout-arg target is defined

### DIFF
--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -99,6 +99,7 @@ class Component(components.ComponentBase):
             arg_job["verb"] = "ARG"
             arg_job["args"] = {stdout_arg: clean_info}
             arg_job["parent_async_bypass"] = True
+            arg_job["targets"] = [self.driver.identity]
             arg_job["job_id"] = utils.get_uuid()
             arg_job["job_sha3_224"] = utils.object_sha3_224(obj=arg_job)
             arg_job["parent_id"] = utils.get_uuid()


### PR DESCRIPTION
When running RUN with --stdout-arg we need to to ensure that
the ARG is scoped to the correct node. This change uses the
driver identity to ensure the callback ARG is scoped accordingly.

Fixes: https://github.com/cloudnull/directord/issues/164
Signed-off-by: Kevin Carter <kecarter@redhat.com>