### PR TITLE
ensure we're only blocking for tasks that have ended or failed

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -466,7 +466,6 @@ class Client(interface.Interface):
                         ) in [
                             self.driver.job_end.decode(),
                             self.driver.job_failed.decode(),
-                            self.driver.nullbyte.decode(),
                         ]:
                             block_on_task = False
                         else:
@@ -474,7 +473,7 @@ class Client(interface.Interface):
                                 "waiting for callback job to complete. %s",
                                 block_on_task_data,
                             )
-                            time.sleep(1)
+                            time.sleep(0.5)
 
                 self.log.debug(
                     "Task sha [ %s ] callback complete",


### PR DESCRIPTION
this will ensure we're only allowing call back tasks to block until failed or success status. 

tasks can have a null status while pending, the call back task was releasing the block too early in some cases. this will ensure we're blocking correctly.

Signed-off-by: Kevin Carter <kecarter@redhat.com>