### PR TITLE
add force-lock option

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -425,7 +425,7 @@ class Client(interface.Interface):
             setattr(component, "driver", self.driver)
 
             locked = False
-            if component.requires_lock:
+            if component.requires_lock or job.get("force_lock", False) is True:
                 lock.acquire()
                 locked = True
 
@@ -682,7 +682,8 @@ class Client(interface.Interface):
                 if not locker:
                     parent_locks_tracker.remove(item)
                     self.log.debug(
-                        "Lock item:%s removed as it is no longer active.", item
+                        "Lock item:%s removed as it is no longer active.",
+                        item,
                     )
                 else:
                     locked = locker.acquire(block=False)

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -243,6 +243,11 @@ class ComponentBase:
             type=int,
             help="Set the action timeout. Default %(default)s.",
         )
+        self.parser.add_argument(
+            "--force-lock",
+            action="store_true",
+            help="Force a given task to run with a lock.",
+        )
 
     @staticmethod
     def set_cache(

--- a/directord/tests/test_components.py
+++ b/directord/tests/test_components.py
@@ -75,6 +75,7 @@ class TestComponents(unittest.TestCase):
                 "skip_cache": False,
                 "run_once": False,
                 "timeout": 600,
+                "force_lock": False,
                 "snake_case": "test",
                 "opt0": "*.json",
                 "opt1": None,

--- a/docs/components.md
+++ b/docs/components.md
@@ -5,6 +5,21 @@
 
 Components power Directord and provide well documented interfaces.
 
+### Basic Component Options
+
+All component inherit the following basic options.
+
+
+* `--exec-help`        Show this execution help message.
+
+* `--skip-cache`       For a task to skip the on client cache.
+
+* `--run-once`         Force a given task to run once.
+
+* `--timeout` `STRING` Set the action timeout. Default 600.
+
+* `--force-lock`       Force a given task to run with a lock.
+
 ### Built-in Components
 
 The following section covers all of the built-in components Directord ships with.
@@ -319,7 +334,10 @@ orchestrations.
   [here](https://github.com/cloudnull/directord/blob/main/components/echo.py).
 
 
-###### Help Information From User Defined Component
+###### Help Information From Components
+
+All components have access to `--exec-help` which will provide information on
+specific options a component has.
 
 ``` shell
 $ directord exec --verb ECHO "--exec-help true"
@@ -335,6 +353,7 @@ optional arguments:
   --skip-cache       For a task to skip the on client cache.
   --run-once         Force a given task to run once.
   --timeout TIMEOUT  Set the action timeout. Default 600.
+  --force-lock       Force a given task to run with a lock.
 ```
 
 ###### Executing a User Defined Component


### PR DESCRIPTION
Operators can now force a task to run with a lock, which will allow
users to define blocking operations.

Signed-off-by: Kevin Carter <kecarter@redhat.com>