### PR TITLE
remove artificial time blocks

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -826,7 +826,7 @@ class Client(interface.Interface):
 
         self.bind_job = self.driver.job_connect()
         poller_time = time.time()
-        poller_interval = 8
+        poller_interval = 1
         cache_check_time = time.time()
 
         # Ensure that the cache path exists before executing.
@@ -854,7 +854,7 @@ class Client(interface.Interface):
             if self.driver.bind_check(
                 bind=self.bind_job, constant=poller_interval
             ):
-                poller_interval, poller_time = 8, time.time()
+                poller_interval, poller_time = 1, time.time()
                 (
                     _,
                     _,

--- a/directord/server.py
+++ b/directord/server.py
@@ -435,7 +435,7 @@ class Server(interface.Interface):
             else:
                 self.return_jobs[job_id] = job_info
 
-        return 8, time.time()
+        return 1, time.time()
 
     def run_interactions(self, sentinel=False):
         """Execute the interactions loop.
@@ -455,7 +455,7 @@ class Server(interface.Interface):
         self.bind_job = self.driver.job_bind()
         self.bind_transfer = self.driver.transfer_bind()
         poller_time = time.time()
-        poller_interval = 8
+        poller_interval = 1
 
         while True:
             current_time = time.time()
@@ -472,7 +472,7 @@ class Server(interface.Interface):
             if self.driver.bind_check(
                 bind=self.bind_transfer, constant=poller_interval
             ):
-                poller_interval, poller_time = 8, time.time()
+                poller_interval, poller_time = 1, time.time()
 
                 (
                     identity,
@@ -510,7 +510,7 @@ class Server(interface.Interface):
             elif self.driver.bind_check(
                 bind=self.bind_job, constant=poller_interval
             ):
-                poller_interval, poller_time = 8, time.time()
+                poller_interval, poller_time = 1, time.time()
                 (
                     identity,
                     msg_id,

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -465,7 +465,7 @@ class TestServer(tests.TestDriverBase):
         self.server.job_queue = mock_queue
         self.server.workers = {b"test-node1": 12345, b"test-node2": 12345}
         return_int, _ = self.server.run_job()
-        self.assertEqual(return_int, 8)
+        self.assertEqual(return_int, 1)
         mock_log_debug.assert_called()
         self.mock_driver.socket_send.assert_called()
 


### PR DESCRIPTION
This change sets the time block to 0.01 when work is present, which is a
reasonable poller duration. The old blocks were used to capture work and
simualte a busy environment. While the old blocks we're by no means
slow, this change will imporve execution by an order of magnatude.

Signed-off-by: Kevin Carter <kecarter@redhat.com>