### PR TITLE
Server return and async tracing

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -874,10 +874,14 @@ class Client(interface.Interface):
 
         lock = self.get_lock()
         threads = [
-            (self.thread(target=self.run_heartbeat), True),
-            (self.thread(target=self.run_job), True),
+            (
+                self.thread(name="run_heartbeat", target=self.run_heartbeat),
+                True,
+            ),
+            (self.thread(name="run_job", target=self.run_job), True),
             (
                 self.thread(
+                    name="job_q_processor",
                     target=self.job_q_processor,
                     kwargs=dict(lock=lock),
                 ),

--- a/directord/components/builtin_run.py
+++ b/directord/components/builtin_run.py
@@ -87,8 +87,8 @@ class Component(components.ComponentBase):
         )
 
         if stdout_arg and stdout:
-            clean_info = stdout.decode().strip()
             self.block_on_tasks = list()
+            clean_info = stdout.decode().strip()
             arg_job = job.copy()
             arg_job.pop("parent_sha3_224", None)
             arg_job.pop("parent_id", None)
@@ -105,6 +105,5 @@ class Component(components.ComponentBase):
             arg_job["parent_id"] = utils.get_uuid()
             arg_job["parent_sha3_224"] = utils.object_sha3_224(obj=arg_job)
             self.block_on_tasks.append(arg_job)
-            self.log.debug("Job call backs: %s ", self.block_on_tasks)
 
         return stdout, stderr, outcome, command.encode()

--- a/directord/main.py
+++ b/directord/main.py
@@ -253,6 +253,11 @@ def _args(exec_args=None):
         ),
         action="store_true",
     )
+    parser_exec.add_argument(
+        "--force-async",
+        help=("Instruct the execution engine to run asynchronously."),
+        action="store_true",
+    )
     parser_server = subparsers.add_parser("server", help="Server mode help")
     parser_server.add_argument(
         "--bind-address",

--- a/directord/mixin.py
+++ b/directord/mixin.py
@@ -295,6 +295,7 @@ class Mixin:
         format_kwargs = dict(
             verb=self.args.verb,
             execute=self.args.exec,
+            parent_async=getattr(self.args, "force_async", False),
             return_raw=getattr(self.args, "poll", False),
         )
         if self.args.target:

--- a/directord/server.py
+++ b/directord/server.py
@@ -408,13 +408,24 @@ class Server(interface.Interface):
                             " the available targets",
                             target,
                         )
+                        self._set_job_status(
+                            job_status=self.driver.job_failed,
+                            job_id=job_item["job_id"],
+                            identity=target,
+                            job_output=(
+                                "Target unknown. Available targets {}".format(
+                                    list(self.workers.keys())
+                                )
+                            ),
+                            recv_time=time.time(),
+                        )
 
                 if not targets:
                     self.log.error("No known targets defined.")
                     time.sleep(poller_interval * 0.001)
                     continue
 
-                self.log.debug("All targets [ %s ]", targets)
+                self.log.debug("All targets %s", targets)
                 if job_item["verb"] == "QUERY":
                     self.log.debug("Query mode enabled.")
                     job_item["targets"] = [i.decode() for i in targets]
@@ -512,22 +523,22 @@ class Server(interface.Interface):
                     log=self.log,
                 )
 
-            while self.workers and not self.send_queue.empty():
-                try:
-                    send_item = self.send_queue.get_nowait()
-                except Exception:
-                    break
-                else:
-                    self.log.debug(
-                        "Sending job [ %s ] sent to [ %s ]",
-                        send_item["data"]["job_id"],
-                        send_item["identity"].decode(),
-                    )
-                    send_item["data"] = json.dumps(send_item["data"]).encode()
-                    self.driver.socket_send(
-                        socket=self.bind_job,
-                        **send_item,
-                    )
+            try:
+                send_item = self.send_queue.get_nowait()
+            except Exception:
+                pass
+            else:
+                poller_interval, poller_time = 1, time.time()
+                self.log.debug(
+                    "Sending job [ %s ] sent to [ %s ]",
+                    send_item["data"]["job_id"],
+                    send_item["identity"].decode(),
+                )
+                send_item["data"] = json.dumps(send_item["data"]).encode()
+                self.driver.socket_send(
+                    socket=self.bind_job,
+                    **send_item,
+                )
 
             if self.driver.bind_check(
                 bind=self.bind_transfer, constant=poller_interval
@@ -767,10 +778,23 @@ class Server(interface.Interface):
         """
 
         threads = [
-            (self.thread(target=self.run_socket_server), True),
-            (self.thread(target=self.run_heartbeat), True),
-            (self.thread(target=self.run_interactions), True),
-            (self.thread(target=self.run_job), True),
+            (
+                self.thread(
+                    name="run_socket_server", target=self.run_socket_server
+                ),
+                True,
+            ),
+            (
+                self.thread(name="run_heartbeat", target=self.run_heartbeat),
+                True,
+            ),
+            (
+                self.thread(
+                    name="run_interactions", target=self.run_interactions
+                ),
+                True,
+            ),
+            (self.thread(name="run_job", target=self.run_job), True),
         ]
 
         if self.args.run_ui:
@@ -780,6 +804,8 @@ class Server(interface.Interface):
             ui_obj = ui.UI(
                 args=self.args, jobs=self.return_jobs, nodes=self.workers
             )
-            threads.append((self.thread(target=ui_obj.start_app), True))
+            threads.append(
+                (self.thread(name="ui", target=ui_obj.start_app), True)
+            )
 
         self.run_threads(threads=threads)

--- a/directord/tests/test_main.py
+++ b/directord/tests/test_main.py
@@ -91,6 +91,7 @@ class TestMain(unittest.TestCase):
                 "verb": "RUN",
                 "target": None,
                 "exec": ["command1"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -118,6 +119,7 @@ class TestMain(unittest.TestCase):
                 "verb": "COPY",
                 "target": None,
                 "exec": ["file1 file2"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -145,6 +147,7 @@ class TestMain(unittest.TestCase):
                 "verb": "ADD",
                 "target": None,
                 "exec": ["file1 file2"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -172,6 +175,7 @@ class TestMain(unittest.TestCase):
                 "verb": "ARG",
                 "target": None,
                 "exec": ["key value"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -199,6 +203,7 @@ class TestMain(unittest.TestCase):
                 "verb": "ENV",
                 "target": None,
                 "exec": ["key value"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -227,6 +232,7 @@ class TestMain(unittest.TestCase):
                 "verb": "WORKDIR",
                 "target": None,
                 "exec": ["/path"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -254,6 +260,7 @@ class TestMain(unittest.TestCase):
                 "verb": "CACHEFILE",
                 "target": None,
                 "exec": ["/path"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -281,6 +288,7 @@ class TestMain(unittest.TestCase):
                 "verb": "CACHEEVICT",
                 "target": None,
                 "exec": ["all"],
+                "force_async": False,
                 "poll": False,
             },
         )
@@ -308,6 +316,7 @@ class TestMain(unittest.TestCase):
                 "verb": "QUERY",
                 "target": None,
                 "exec": ["var"],
+                "force_async": False,
                 "poll": False,
             },
         )

--- a/directord/tests/test_mixin.py
+++ b/directord/tests/test_mixin.py
@@ -307,9 +307,10 @@ class TestMixin(tests.TestConnectionBase):
                 {
                     "verb": "QUERY",
                     "query": "test",
+                    "no_wait": False,
                     "timeout": 600,
                     "run_once": False,
-                    "job_sha3_224": "6a3389639ebec5f7bcae998f73545fb9efb9cc975a38606168b6ceb9",  # noqa
+                    "job_sha3_224": "1ff48da6d87a9f451029040c02f99cf26efa6614e5af7a20ba53352d",  # noqa
                     "return_raw": False,
                     "skip_cache": False,
                 }


### PR DESCRIPTION
Async tasks will now use the parent ID within the queue name. This is
done so that operators can now see when a queue is executing and when it
is pruned.

Allow query to run without waiting for the cache to be populated with
the queried value.

All exec tasks can now be forced into an async mode.
