### PR TITLE
Save a reference to zmq Driver, and restore it for each unit test

### DIFF
--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 from collections import namedtuple
 
 from directord import drivers
+from directord.drivers import zmq
 
 
 TEST_BLUEPRINT_CONTENT = "This is a blueprint string {{ test }}"
@@ -245,6 +246,7 @@ class TestConnectionBase(unittest.TestCase):
 
 class TestDriverBase(unittest.TestCase):
     def setUp(self):
+        self.zmq = zmq.Driver
         base_driver = drivers.BaseDriver(args=FakeArgs())
         self.mock_driver_patched = patch(
             "directord.drivers.BaseDriver",
@@ -262,6 +264,10 @@ class TestDriverBase(unittest.TestCase):
         self.mock_driver.job_failed = base_driver.job_failed
         self.mock_driver.transfer_start = base_driver.transfer_start
         self.mock_driver.transfer_end = base_driver.transfer_end
+        self.addCleanup(self.restoreZmq)
+
+    def restoreZmq(self):
+        zmq.Driver = self.zmq
 
     def tearDown(self) -> None:
         self.mock_driver_patched.stop()


### PR DESCRIPTION
Without this patch, running a subset of unit tests that inherit from
directord.tests.TestDriverBase fail like so:

$ .tox/coverage/bin/python -m unittest directord.tests.test_user.TestManager
...
TypeError: __name__ must be set to a string object

The zmq.Driver class is correctly unmocked for some reason.

Signed-off-by: James Slagle <jslagle@redhat.com>
