### PR TITLE
Healthcheck isolation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -462,7 +462,7 @@ jobs:
           cd /opt/directord/share/directord/orchestrations
           sudo timeout 240 /opt/directord/bin/directord \
                                               orchestrate \
-                                              {functional-tests-async-race.yaml,functional-tests-async-time.yaml,functional-tests-async.yaml,functional-tests-query.yaml,functional-tests-async-transfer.yaml,functional-tests.yaml} \
+                                              {functional-tests-async-race.yaml,functional-tests-async-time.yaml,functional-tests-async.yaml,functional-tests-query.yaml,functional-tests-async-transfer.yaml} \
                                               --poll \
                                               --check
       - name: Generate log details

--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -81,7 +81,7 @@ class Component(components.ComponentBase):
                     "Job {} found complete".format(job["sha"]),
                 )
 
-            time.sleep(1)
+            self.delay(1)
 
         return (
             None,

--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -14,6 +14,8 @@
 
 import time
 
+from multiprocessing import Event
+
 from directord import components
 
 
@@ -119,6 +121,12 @@ class Component(components.ComponentBase):
                             )
                         ),
                     )
+                if missing_identity:
+                    self.log.warning(
+                        "QUERY argument [ %s ] not found in cache for %s",
+                        job["item"],
+                        missing_identity,
+                    )
             else:
                 for value in query_args.values():
                     if job["item"] in value:
@@ -130,7 +138,10 @@ class Component(components.ComponentBase):
                                 job["item"]
                             ),
                         )
-            time.sleep(1)
+            self.log.warning(
+                "QUERY argument [ %s ] not found in cache", job["item"]
+            )
+            Event().wait(2)
 
         if missing_identity:
             info = (

--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -14,8 +14,6 @@
 
 import time
 
-from multiprocessing import Event
-
 from directord import components
 
 
@@ -141,7 +139,7 @@ class Component(components.ComponentBase):
             self.log.warning(
                 "QUERY argument [ %s ] not found in cache", job["item"]
             )
-            Event().wait(2)
+            self.delay(2)
 
         if missing_identity:
             info = (

--- a/directord/bootstrap.py
+++ b/directord/bootstrap.py
@@ -153,7 +153,7 @@ class Bootstrap(directord.Processor):
         return return_jobs
 
     @staticmethod
-    def _read_chunks(fh, chunk_size=2048):
+    def _read_chunks(fh, chunk_size=131072):
         """Read file in 2048 chunks."""
 
         while True:
@@ -202,7 +202,7 @@ class Bootstrap(directord.Processor):
 
             flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
             with open(localfile, "rb") as local_f:
-                for data in self._read_chunks(fh=local_f, chunk_size=1024):
+                for data in self._read_chunks(fh=local_f, chunk_size=131072):
                     with chan.open(
                         remotefile, flags, fileinfo.st_mode
                     ) as remote_f:

--- a/directord/client.py
+++ b/directord/client.py
@@ -12,6 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import collections
 import datetime
 import json
 import os
@@ -85,22 +86,16 @@ class Client(interface.Interface):
         :returns: Object
         """
 
-        if (threads <= processes) and not queue.empty():
-            self.log.debug(
-                "Executing new thread for parent queue [ %s ]",
-                name,
-            )
-            thread = self.thread(
-                target=self.q_processor,
-                kwargs=dict(
-                    queue=queue,
-                    lock=lock,
-                ),
-                name=name,
-                daemon=True,
-            )
-            thread.start()
-            return thread
+        thread = self.thread(
+            target=self.q_processor,
+            kwargs=dict(
+                queue=queue,
+                lock=lock,
+            ),
+            name=name,
+            daemon=True,
+        )
+        return thread
 
     def job_q_processor(self, q_processes, lock=None):
         """Process a given work queue.
@@ -114,35 +109,60 @@ class Client(interface.Interface):
         :type lock: Object
         """
 
-        def _parent_prune(parents, parent):
-            """Prune parent objects when possible.
+        def _get_pending_bypass_threads(parents):
+            """Return the current non-bypass thread objects.
 
             :param parents: Dictionary of all parent objects.
             :type parents: Dictionary
-            :param parent: Name of parent to check.
-            :type parent: String
-            :returns: Boolean
+            :returns: List
             """
 
-            timestamp = time.time()
-            if "time" not in parents[parent]:
-                parents[parent]["time"] = timestamp
-                self.log.debug(
-                    "Parent [ %s ] begining prune",
-                    parent,
-                )
-            elif timestamp - parents[parent].get("time", timestamp) >= 30:
-                parents.pop(parent)
-                self.log.info("Pruned parent [ %s ]", parent)
-                return True
-            return False
+            return [
+                i["t"].name
+                for i in parents.values()
+                if i["bypass"]
+                and not i["t"].is_alive()
+                and i["t"].exitcode is None
+            ]
+
+        def _get_pending_threads(parents):
+            """Return the current non-bypass thread objects.
+
+            :param parents: Dictionary of all parent objects.
+            :type parents: Dictionary
+            :returns: List
+            """
+
+            return [
+                i["t"].name
+                for i in parents.values()
+                if not i["bypass"]
+                and not i["t"].is_alive()
+                and i["t"].exitcode is None
+            ]
+
+        def _get_thread_count(parents):
+            """Return the current non-bypass thread count.
+
+            :param parents: Dictionary of all parent objects.
+            :type parents: Dictionary
+            :returns: Integer
+            """
+
+            return len(
+                [
+                    True
+                    for i in parents.values()
+                    if not i["bypass"] and i["t"].is_alive()
+                ]
+            )
 
         if not lock:
             lock = self.get_lock()
 
-        parent_tracker = dict()
-        bypass_threads = set()
-        while not q_processes.empty() or bypass_threads or parent_tracker:
+        loop_time = time.time()
+        parent_tracker = collections.OrderedDict()
+        while not q_processes.empty() or parent_tracker:
             try:
                 (
                     component_kwargs,
@@ -151,65 +171,9 @@ class Client(interface.Interface):
                 ) = q_processes.get_nowait()
             except ValueError as e:
                 self.log.critical("Queue object value error [ %s ]", str(e))
-                continue
+                pass
             except Exception:
-                for t in list(bypass_threads):
-                    if t.is_alive():
-                        bypass_threads.remove(t)
-
-                for key, value in list(parent_tracker.items()):
-                    if value["t"]:
-                        if value["t"].exitcode is None:
-                            parent_tracker[key].pop("time", None)
-                        elif value["q"].empty():
-                            if _parent_prune(
-                                parents=parent_tracker, parent=key
-                            ):
-                                self.terminate_process(process=value["t"])
-                                value["q"].close()
-                                value["q"].join_thread()
-                        else:
-                            self.log.info(
-                                "Dead parent [ %s ] found with queue items,"
-                                " resetting parent thread",
-                                key,
-                            )
-                            parent_tracker[key]["t"] = None
-                            parent_tracker[key].pop("time", None)
-                    elif value["q"].empty():
-                        if _parent_prune(parents=parent_tracker, parent=key):
-                            self.terminate_process(process=value["t"])
-                            value["q"].close()
-                            value["q"].join_thread()
-                    else:
-                        if value["bypass"]:
-                            t = self._process_spawn(
-                                lock=lock,
-                                queue=value["q"],
-                                threads=0,
-                                name=key,
-                            )
-                            if t:
-                                bypass_threads.add(t)
-                        else:
-                            _threads = len(
-                                [
-                                    True
-                                    for i in parent_tracker.values()
-                                    if not i["bypass"]
-                                    and i["t"]
-                                    and i["t"].is_alive()
-                                ]
-                            )
-                            t = parent_tracker[key]["t"] = self._process_spawn(
-                                lock=lock,
-                                queue=value["q"],
-                                threads=_threads,
-                                name=key,
-                            )
-                            if t:
-                                parent_tracker[key].pop("time", None)
-                time.sleep(0.1)
+                pass
             else:
                 job = component_kwargs["job"]
                 self.log.debug("Received job_id [ %s ]", job["job_id"])
@@ -219,7 +183,7 @@ class Client(interface.Interface):
                 #                  the component structure.
                 if command.decode().lower() == "queuesentinel":
                     count = 0
-                    for key, value in list(parent_tracker.items()):
+                    for _, value in list(parent_tracker.items()):
                         count += self.purge_queue(
                             queue=value["q"], job_id=job["job_id"]
                         )
@@ -242,39 +206,57 @@ class Client(interface.Interface):
                     _parent = parent_tracker[_q_name]
                 else:
                     _parent = parent_tracker[_q_name] = dict(
-                        t=None, q=self.get_queue(), bypass=False
+                        t=None,
+                        q=self.get_queue(),
+                        bypass=job.get("parent_async_bypass", False),
                     )
                     self.log.info("Parent queue [ %s ] created.", _q_name)
 
                 _parent["q"].put((component_kwargs, command, info))
-
-                if _parent["t"] and _parent["t"].is_alive():
-                    continue
-                elif _q_name.startswith("q_bypass"):
-                    parent_tracker[_q_name]["bypass"] = True
-                    t = self._process_spawn(
-                        lock=lock,
-                        queue=_parent["q"],
-                        threads=0,
-                        name=_q_name,
-                    )
-                    if t:
-                        bypass_threads.add(t)
-                else:
-                    parent_tracker[_q_name]["t"] = self._process_spawn(
-                        lock=lock,
-                        queue=_parent["q"],
-                        threads=len(
-                            [
-                                True
-                                for i in parent_tracker.values()
-                                if not i["bypass"]
-                                and i["t"]
-                                and i["t"].is_alive()
-                            ]
+                if not _parent["t"]:
+                    _parent["t"] = self.thread(
+                        target=self.q_processor,
+                        kwargs=dict(
+                            queue=_parent["q"],
+                            lock=lock,
                         ),
                         name=_q_name,
+                        daemon=True,
                     )
+
+            while _get_thread_count(parents=parent_tracker) <= 5:
+                for t in _get_pending_threads(parents=parent_tracker):
+                    self.log.info("Starting process [ %s ]", t)
+                    parent_tracker[t]["t"].start()
+                else:
+                    break
+
+            for t in _get_pending_bypass_threads(parents=parent_tracker):
+                self.log.info("Starting bypass process [ %s ]", t)
+                parent_tracker[t]["t"].start()
+
+            for key, value in list(parent_tracker.items()):
+                if value["t"].is_alive() or value["t"].exitcode is None:
+                    continue
+                else:
+                    self.terminate_process(process=value["t"])
+                    value["q"].close()
+                    value["q"].join_thread()
+                    parent_tracker.pop(key)
+                    self.log.info("Pruned parent [ %s ]", key)
+
+            if time.time() > loop_time:
+                known_parents = list(parent_tracker.keys())
+                if known_parents:
+                    self.log.info("Known parents: %s", known_parents)
+
+                self.log.info(
+                    "Active processes: %s",
+                    _get_thread_count(parents=parent_tracker),
+                )
+                loop_time = time.time() + 30
+
+            time.sleep(0.01)
 
     def purge_queue(self, queue, job_id):
         """Purge all jobs from the queue.
@@ -686,27 +668,24 @@ class Client(interface.Interface):
         """
 
         if time.time() > cache_check_time + 4096:
-            with diskcache.Cache(
-                self.args.cache_path, tag_index=True
-            ) as cache:
-                self.log.info(
-                    "Current estimated cache size: %s KiB",
-                    cache.volume() / 1024,
+            self.log.info(
+                "Current estimated cache size: %s KiB",
+                self.cache.volume() / 1024,
+            )
+
+            warnings = self.cache.check()
+            if warnings:
+                self.log.warning(
+                    "Client cache noticed %s warnings.", len(warnings)
                 )
-
-                warnings = cache.check()
-                if warnings:
+                for item in warnings:
                     self.log.warning(
-                        "Client cache noticed %s warnings.", len(warnings)
+                        "Client Cache Warning: [ %s ].",
+                        str(item.message),
                     )
-                    for item in warnings:
-                        self.log.warning(
-                            "Client Cache Warning: [ %s ].",
-                            str(item.message),
-                        )
 
-                cache.expire()
-                return time.time()
+            self.cache.expire()
+            return time.time()
 
         return cache_check_time
 

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -259,7 +259,7 @@ class ComponentBase:
         key,
         value,
         value_update=False,
-        expire=28800,
+        expire=259200,
         tag=None,
         extend=False,
     ):
@@ -280,6 +280,7 @@ class ComponentBase:
         :type tag: String
         :param extend: Enable|Disable Extend a map
         :type extend: Boolean
+        :returns" Boolean
         """
 
         if value_update:
@@ -291,7 +292,10 @@ class ComponentBase:
             except (ValueError, AttributeError):
                 pass
 
-        cache.set(key, value, tag=tag, expire=expire, retry=True)
+        cache_set = cache.set(key, value, tag=tag, expire=expire, retry=True)
+        if not cache_set:
+            return cache.set(key, value, tag=tag, expire=expire, retry=True)
+        return cache_set
 
     def file_blueprinter(self, cache, file_to):
         """Read a file and blueprint its contents.

--- a/directord/components/__init__.py
+++ b/directord/components/__init__.py
@@ -16,6 +16,8 @@ import argparse
 import os
 import subprocess
 
+from multiprocessing import Event
+
 import jinja2
 from jinja2 import StrictUndefined
 
@@ -34,6 +36,7 @@ class ComponentBase:
     verb = None
     block_on_tasks = None
     queue_sentinel = False
+    delay = Event().wait
 
     def __init__(self, desc=None):
         """Initialize the component base class.

--- a/directord/components/builtin_arg.py
+++ b/directord/components/builtin_arg.py
@@ -111,7 +111,7 @@ class Component(components.ComponentBase):
             cache_value = json.loads(value)
 
         if cache_value:
-            self.set_cache(
+            cache_set = self.set_cache(
                 cache=cache,
                 key=cache_type,
                 value=cache_value,
@@ -119,12 +119,29 @@ class Component(components.ComponentBase):
                 tag=cache_type,
                 extend=job.get("extend_args", False),
             )
-            return (
-                "{} added to cache".format(cache_type),
-                None,
-                True,
-                "type:{}, value:{}".format(cache_type, cache_value).encode(),
-            )
+            if cache_set:
+                self.log.debug(
+                    "ARG [ %s ] = [ %s ] added to cache",
+                    cache_type,
+                    cache_value,
+                )
+                return (
+                    "{} added to cache".format(cache_type),
+                    None,
+                    True,
+                    "type:{}, value:{}".format(
+                        cache_type, cache_value
+                    ).encode(),
+                )
+            else:
+                return (
+                    None,
+                    "Failed to add {} to cache".format(cache_type),
+                    False,
+                    "type:{}, value:{}".format(
+                        cache_type, cache_value
+                    ).encode(),
+                )
         else:
             return (
                 "Nothing added to cache. {} had no value".format(cache_type),

--- a/directord/components/builtin_copy.py
+++ b/directord/components/builtin_copy.py
@@ -61,7 +61,7 @@ class Transfer:
                     )
                 else:
                     self.bind_transfer.close(linger=2)
-                    time.sleep(1)
+                    self.delay(1)
         except Exception as e:
             self.log.error(
                 "Job [ %s ] transfer ran into an exception"

--- a/directord/datastores/disc.py
+++ b/directord/datastores/disc.py
@@ -106,7 +106,7 @@ class BaseDocument:
         method will pop all items from the object.
         """
 
-        self.datastore.clear()
+        self.datastore.clear(retry=True)
 
     def pop(self, key):
         """Delete the value of a given key.

--- a/directord/tests/test_client.py
+++ b/directord/tests/test_client.py
@@ -28,85 +28,6 @@ class TestClient(tests.TestDriverBase):
         self.client = client.Client(args=self.args)
         self.client.driver = self.mock_driver
 
-    @patch("logging.Logger.debug", autospec=True)
-    def test_run_heartbeat(self, mock_log_debug):
-        self.mock_driver.socket_recv.side_effect = [
-            (None, None, None, json.dumps({}).encode(), b".001", None, None)
-        ]
-        self.client.run_heartbeat(sentinel=True)
-        mock_log_debug.assert_called()
-
-    @patch("logging.Logger.warning", autospec=True)
-    def test_run_heartbeat_reset(self, mock_log_warning):
-        self.mock_driver.socket_recv.side_effect = [
-            (
-                None,
-                None,
-                b"reset",
-                json.dumps({}).encode(),
-                b".001",
-                None,
-                None,
-            )
-        ]
-        self.client.run_heartbeat(sentinel=True)
-        mock_log_warning.assert_called()
-
-    @patch("time.time", autospec=True)
-    @patch("time.sleep", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
-    def test_run_heartbeat_missed(self, mock_log_debug, mock_sleep, mock_time):
-        mock_time.side_effect = [1, 1, 1, 1, 1, 1]
-        self.mock_driver.socket_recv.side_effect = [
-            (None, None, None, json.dumps({}).encode(), b".001", None, None)
-        ]
-        with patch.object(self.mock_driver, "bind_check", return_value=False):
-            with patch.object(
-                self.mock_driver, "get_heartbeat", return_value=0
-            ):
-                self.client.run_heartbeat(sentinel=True, heartbeat_misses=10)
-        mock_log_debug.assert_called()
-        mock_sleep.assert_called()
-
-    @patch("time.time", autospec=True)
-    @patch("time.sleep", autospec=True)
-    @patch("logging.Logger.debug", autospec=True)
-    def test_run_heartbeat_missed_long_interval(
-        self, mock_log_debug, mock_sleep, mock_time
-    ):
-        mock_time.side_effect = [1, 1, 1, 1, 1, 1]
-        self.mock_driver.socket_recv.side_effect = [
-            (None, None, None, json.dumps({}).encode(), b".001", None, None)
-        ]
-        with patch.object(self.mock_driver, "bind_check", return_value=False):
-            with patch.object(
-                self.mock_driver, "get_heartbeat", return_value=0
-            ):
-                self.client.heartbeat_failure_interval = 64
-                self.client.run_heartbeat(sentinel=True, heartbeat_misses=10)
-        mock_log_debug.assert_called()
-        mock_sleep.assert_called()
-
-    @patch("time.time", autospec=True)
-    def test_run_heartbeat_update(self, mock_time):
-        mock_time.side_effect = [1, 1, 1, 1, 1, 1]
-        self.mock_driver.socket_recv.side_effect = [
-            (
-                None,
-                None,
-                b"reset",
-                json.dumps({}).encode(),
-                b".001",
-                None,
-                None,
-            )
-        ]
-        with patch.object(self.mock_driver, "bind_check", return_value=False):
-            with patch.object(
-                self.mock_driver, "get_heartbeat", return_value=0
-            ):
-                self.client.run_heartbeat(sentinel=True)
-
     @patch("time.time", autospec=True)
     def test_run_job(self, mock_time):
         mock_time.side_effect = [1, 1, 1, 1, 1, 1]
@@ -345,6 +266,6 @@ class TestClient(tests.TestDriverBase):
     @patch("directord.client.Client.run_threads", autospec=True)
     def test_worker_run(self, mock_run_threads, mock_diskcache, mock_makedirs):
         self.client.worker_run()
-        mock_run_threads.assert_called_with(ANY, threads=[ANY, ANY])
+        mock_run_threads.assert_called_with(ANY, threads=[ANY])
         mock_diskcache.assert_called()
         mock_makedirs.assert_called()

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -490,7 +490,7 @@ class TestServer(tests.TestDriverBase):
                 None,
             ),
         ]
-        mock_time.side_effect = [1, 1, 1, 1, 1, 1]
+        mock_time.side_effect = [1, 1, 1, 1, 1, 1, 1, 1]
         self.server.run_interactions(sentinel=True)
 
     @patch("time.time", autospec=True)
@@ -517,7 +517,7 @@ class TestServer(tests.TestDriverBase):
                 None,
             ),
         ]
-        mock_time.side_effect = [1, 66, 1, 1, 1, 1]
+        mock_time.side_effect = [1, 66, 1, 1, 1, 1, 1, 1]
         self.server.run_interactions(sentinel=True)
 
     @patch("time.time", autospec=True)
@@ -544,7 +544,7 @@ class TestServer(tests.TestDriverBase):
                 None,
             ),
         ]
-        mock_time.side_effect = [1, 34, 1, 1, 1, 1]
+        mock_time.side_effect = [1, 34, 1, 1, 1, 1, 1, 1]
         self.server.run_interactions(sentinel=True)
 
     @patch("time.time", autospec=True)

--- a/directord/utils.py
+++ b/directord/utils.py
@@ -320,12 +320,7 @@ def return_poller_interval(poller_time, poller_interval, log=None):
     """
 
     current_time = time.time()
-    if current_time >= poller_time + 1024:
-        if poller_interval != 4096:
-            if log:
-                log.debug("Directord entering sleep state.")
-        poller_interval = 4096
-    elif current_time >= poller_time + 64:
+    if current_time >= poller_time + 64:
         if poller_interval != 2048:
             if log:
                 log.debug("Directord entering idle state.")


### PR DESCRIPTION
This change reworks our health check process which ensures we're running
a very lean application with all the required functionality.

* The health check thread was remove.
* The client q processor now uses an ordered dict to manage the threads which ensures consistent execution.
* cache adds will now automatically retry and return the state of the cache add attempt which will help ensure we're recording the job execution appropriately.
* Client thread spawning is now totally dynamic. At idle, there's now only one PID.