### PR TITLE
Remove the use of the server side heartbeat socket

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -40,8 +40,6 @@ class Client(interface.Interface):
 
         super(Client, self).__init__(args=args)
 
-        self.heartbeat_failure_interval = 2
-        self.bind_heatbeat = None
         self.q_return = self.get_queue()
         self.base_component = components.ComponentBase()
         self.cache = dict()
@@ -705,7 +703,6 @@ class Client(interface.Interface):
         :type sentinel: Boolean
         """
 
-        self.bind_heatbeat = self.driver.heartbeat_connect()
         self.bind_job = self.driver.job_connect()
         poller_time = time.time()
         heartbeat_time = time.time()
@@ -739,7 +736,7 @@ class Client(interface.Interface):
                     uptime = float(f.readline().split()[0])
 
                 self.driver.socket_send(
-                    socket=self.bind_heatbeat,
+                    socket=self.bind_job,
                     control=self.driver.heartbeat_notice,
                     data=json.dumps(
                         {
@@ -758,7 +755,7 @@ class Client(interface.Interface):
                 heartbeat_time = time.time() + 30
                 self.log.info("Heartbeat sent to server")
 
-            if self.driver.bind_check(
+            elif self.driver.bind_check(
                 bind=self.bind_job, constant=poller_interval
             ):
                 poller_interval, poller_time = 1, time.time()
@@ -835,7 +832,6 @@ class Client(interface.Interface):
                 cache_check_time = self.prune_cache(
                     cache_check_time=cache_check_time
                 )
-                time.sleep(poller_interval * 0.001)
 
             if sentinel:
                 break

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -226,7 +226,7 @@ class BaseDriver:
 
         return time.time() + interval
 
-    def get_expiry(self, heartbeat_interval=60, interval=1):
+    def get_expiry(self, heartbeat_interval=60, interval=3):
         """Return a new expiry time.
 
         :param interval: Exponential back off for expiration.

--- a/directord/interface.py
+++ b/directord/interface.py
@@ -54,7 +54,6 @@ class Interface(directord.Processor):
             proto=self.proto, addr=self.bind_address
         )
 
-        self.heartbeat_liveness = 3
         try:
             self.heartbeat_interval = self.args.heartbeat_interval
         except AttributeError:

--- a/docs/service-setup.md
+++ b/docs/service-setup.md
@@ -19,6 +19,5 @@ simple key=value pair.
 
 ``` yaml
 ---
-heartbeat_interval: 1
 debug: true
 ```


### PR DESCRIPTION
Now that the thread pool is dynamic and the socket communication process
has been simplified, we can remove the heartbeat socket all together and
making the application even more simple and lighter. 

* Heartbeats are still used, but they're processed using control objects on the
  on job socket. In a future release we're look to reuse the heartbeat socket
  or remove the code path all together.

Signed-off-by: Kevin Carter <kecarter@redhat.com>