### PR TITLE
when waiting on callbacks, just block on the last one

### DIFF
--- a/components/query_wait.py
+++ b/components/query_wait.py
@@ -139,7 +139,7 @@ class Component(components.ComponentBase):
             self.log.warning(
                 "QUERY argument [ %s ] not found in cache", job["item"]
             )
-            self.delay(1)
+            self.delay(0.5)
 
         if missing_identity:
             info = (


### PR DESCRIPTION
Job callbacks could contain many jobs, because we know that the jobs
will be run serially, this change instructs the client to only wait on
the last job provided.

Signed-off-by: Kevin Carter <kecarter@redhat.com>