### PR TITLE
Add {posargs} to tox coverage command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 
 [testenv:coverage]
 commands =
-    coverage run -a -m unittest
+    coverage run -a -m unittest {posargs}
     coverage report -m --no-skip-covered --skip-empty --fail-under=60 --omit='directord/tests/*,.tox/*'
 
 [testenv:black-check]


### PR DESCRIPTION
Allows for running individual unit tests with tox like so:
tox -e coverage -- directord.tests.test_drivers_zmq

Signed-off-by: James Slagle <jslagle@redhat.com>
