### PR TITLE
Make CLI args override config file

### DIFF
--- a/directord/main.py
+++ b/directord/main.py
@@ -397,6 +397,8 @@ def _args(exec_args=None):
                 else:
                     args.__dict__[key] = value
 
+    # Reparse CLI args so that they override anything from the config file
+    args = parser.parse_args(namespace=args)
     return args, parser
 
 


### PR DESCRIPTION
The CLI arguments should override what is in the config file. This
change adds a step to reparse the CLI args (sys.argv) after options are
read from the config file. When options are common between the CLI and
the config file, the CLI will take precedence.

Signed-off-by: James Slagle <jslagle@redhat.com>
