### PR TITLE
add hostname fencing

### DIFF
--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -52,6 +52,37 @@ class BaseDriver:
         self.log = logger.getLogger(name="directord")
         self.args = args
         self.interface = interface
+        self.machine_id = self.get_machine_id()
+
+    def get_machine_id(self):
+        """Return the unique machine ID.
+
+        This property will iterate through list of known unique identifiers
+        and return the first found with a valid value.
+
+        If no valid unique identifier is found, return the identity.
+
+        :returns: String
+        """
+
+        unique_identifiers = [
+            "/run/machine-id",
+            "/etc/machine-id",
+            "/var/lib/dbus/machine-id",
+            "/sys/class/dmi/id/product_uuid",
+            "/proc/sys/kernel/random/boot_id",
+        ]
+        for identifier in unique_identifiers:
+            try:
+                with open(identifier, "r") as f:
+                    machine_id = f.read().strip()
+            except (FileNotFoundError, PermissionError):
+                pass
+            else:
+                if machine_id:
+                    return machine_id
+        else:
+            return self.identity
 
     def __copy__(self):
         """Return a copy of the base class.

--- a/directord/drivers/messaging.py
+++ b/directord/drivers/messaging.py
@@ -120,6 +120,7 @@ class Driver(drivers.BaseDriver):
                 "version": version,
                 "host_uptime": host_uptime,
                 "agent_uptime": agent_uptime,
+                "machine_id": self.machine_id,
             }
         )
 

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -700,6 +700,7 @@ class Driver(drivers.BaseDriver):
                     "version": version,
                     "host_uptime": host_uptime,
                     "agent_uptime": agent_uptime,
+                    "machine_id": self.machine_id,
                 }
             ),
         )

--- a/directord/main.py
+++ b/directord/main.py
@@ -641,6 +641,7 @@ def main():
                         "VERSION",
                         "HOST_UPTIME",
                         "AGENT_UPTIME",
+                        "MACHINE_ID",
                     ]
                 (
                     tabulated_data,

--- a/directord/server.py
+++ b/directord/server.py
@@ -828,6 +828,23 @@ class Server(interface.Interface):
                 if loaded_data:
                     metadata.update(loaded_data)
 
+        if "machine_id" in metadata:
+            machine_id = metadata.get("machine_id")
+            worker = self.workers.get(identity) or dict()
+            worker_machine_id = worker.get("machine_id")
+            if worker_machine_id and worker_machine_id != machine_id:
+                self.log.fatal(
+                    "Worker [ %s ] not added. Duplicate machines with the"
+                    " same hostname detected. Existing [ %s ] != Incoming"
+                    " [ %s ]. For this node to be added, fix the hostname,"
+                    " reset the machine id, or purge the existing workers"
+                    " and re-enroll the nodes.",
+                    identity,
+                    machine_id,
+                    worker_machine_id,
+                )
+                return
+
         self.workers[identity] = metadata
 
     def worker_run(self):

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -29,11 +29,15 @@ class TestDriverMessaging(unittest.TestCase):
         args = tests.FakeArgs
         args.driver = "messaging"
         args.mode = "server"
-        self.driver = messaging.Driver(
-            args=args,
-            connection_string="amqp://localhost",
-            interface=self.mock_interface,
-        )
+        with patch.object(
+            messaging.Driver, "get_machine_id"
+        ) as mock_get_machine_id:
+            mock_get_machine_id.return_value = "XXX123"
+            self.driver = messaging.Driver(
+                args=args,
+                connection_string="amqp://localhost",
+                interface=self.mock_interface,
+            )
 
     def tearDown(self):
         pass
@@ -41,12 +45,12 @@ class TestDriverMessaging(unittest.TestCase):
     @patch("directord.drivers.messaging.Driver.send")
     def test_heartbeat_send(self, mock_send):
         self.driver.heartbeat_send(10, 11, 12)
-
         data = json.dumps(
             {
                 "version": 12,
                 "host_uptime": 10,
                 "agent_uptime": 11,
+                "machine_id": "XXX123",
             }
         )
         mock_send.assert_called()


### PR DESCRIPTION
While it all hosts should have unique names, it is possible for two
machines to be misconfigured, resulting in multiple machines with the
same host name. To ensure we're able to address machine correctly and
that the server is maintaining a correct inventory, the heartbeat
process will now collect the machine id and use that unique id for
fencing. Should multiple machines with the same hostname but different
machine ids try to join the cluster an error will be raised and the new
node will not be permitted to join. A log entry will be generated on
how to fix the issue.

Signed-off-by: Kevin Carter <kecarter@redhat.com>