### PR TITLE
Fix messaging heartbeat

### DIFF
--- a/directord/client.py
+++ b/directord/client.py
@@ -888,7 +888,7 @@ class Client(interface.Interface):
 
         threads = [
             (
-                self.thread(name="run_driver", target=self.driver.run),
+                self.thread(name="run", target=self.driver.run),
                 True,
             ),
             (

--- a/directord/server.py
+++ b/directord/server.py
@@ -856,7 +856,7 @@ class Server(interface.Interface):
 
         threads = [
             (
-                self.thread(name="run_driver", target=self.driver.run),
+                self.thread(name="run", target=self.driver.run),
                 True,
             ),
             (


### PR DESCRIPTION
Fixes the messaging driver heartbeat by setting up the rpc target as the
machine_id, but still uses the identity (hostname) to identify the
worker in server.py.

Also adds the accidentally removed heartbeat method in messaging.py.

Signed-off-by: James Slagle <jslagle@redhat.com>
