### PR TITLE
D102 updates

### DIFF
--- a/components/job_wait.py
+++ b/components/job_wait.py
@@ -49,6 +49,7 @@ class Component(components.ComponentBase):
 
     def server(self, exec_array, data, arg_vars):
         """Return data from formatted cacheevict action.
+
         :param exec_array: Input array from action
         :type exec_array: List
         :param data: Formatted data hash
@@ -81,6 +82,7 @@ class Component(components.ComponentBase):
 
     def _client(self, cache, job, driver):
         """Run cache query_wait command operation.
+
         :param cache: Caching object used to template items within a command.
         :type cache: Object
         :param job: Information containing the original job specification.

--- a/directord/bootstrap.py
+++ b/directord/bootstrap.py
@@ -28,7 +28,7 @@ from directord import utils
 
 
 class PrintError:
-    def __init__(self) -> None:
+    def __init__(self):
         self.line_break = "="
         self.line_multiplier = 20
         self.start = "Start Error Information"

--- a/directord/client.py
+++ b/directord/client.py
@@ -814,33 +814,18 @@ class Client(interface.Interface):
 
     def handle_job(
         self,
-        identity=None,
-        job_id=None,
-        control=None,
-        command=None,
-        data=None,
-        info=None,
-        stderr=None,
-        stdout=None,
+        command,
+        data,
+        info,
     ):
         """Handle a job interaction.
 
-        :param identity: Client identity
-        :type identity: String
-        :param job_id: Job Id
-        :type job_id: String
-        :param control: Job control character
-        :type control: String
         :param command: Command
         :type command: String
         :param data: Job data
         :type data: Dictionary
         :param info: Job info
         :type info: Dictionary
-        :param stderr: Job stderr output
-        :type stderr: String
-        :param stdout: Job stdout output
-        :type stdout: String
         """
 
         job = json.loads(data)

--- a/directord/drivers/__init__.py
+++ b/directord/drivers/__init__.py
@@ -78,15 +78,15 @@ class BaseDriver:
         pass
 
     def backend_close(self):
-        """Close the backend socket."""
+        """Close the backend."""
 
         pass
 
     def backend_init(self):
-        """Initialize the backend socket
+        """Initialize the backend.
 
-        For server mode, this is a bound local socket.
-        For client mode, it is a connection to the server socket.
+        For server mode, this is a bound local.
+        For client mode, it is a connection to the server.
 
         :returns: Object
         """
@@ -136,7 +136,7 @@ class BaseDriver:
         pass
 
     def backend_send(self, *args, **kwargs):
-        """Send a message over a ZM0 socket.
+        """Send a message over the backend.
 
         The message specification for server is as follows.
 
@@ -271,7 +271,7 @@ class BaseDriver:
         pass
 
     def job_init(self):
-        """Initialize the job socket
+        """Initialize the job socket.
 
         For server mode, this is a bound local socket.
         For client mode, it is a connection to the server socket.

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -566,7 +566,7 @@ class Driver(drivers.BaseDriver):
         return self._recv(socket=self.bind_backend, nonblocking=nonblocking)
 
     def backend_init(self):
-        """Initialize the backend socket
+        """Initialize the backend socket.
 
         For server mode, this is a bound local socket.
         For client mode, it is a connection to the server socket.
@@ -670,7 +670,7 @@ class Driver(drivers.BaseDriver):
         return self._recv(socket=self.bind_job, nonblocking=nonblocking)
 
     def job_init(self):
-        """Initialize the job socket
+        """Initialize the job socket.
 
         For server mode, this is a bound local socket.
         For client mode, it is a connection to the server socket.

--- a/directord/server.py
+++ b/directord/server.py
@@ -211,6 +211,16 @@ class Server(interface.Interface):
             self.lock.release()
 
     def create_return_jobs(self, task, job_item, targets):
+        """Create a job return item if needed.
+
+        :param task: Task UUID information
+        :type task: String
+        :param job_item: Dictionary item for the job definition.
+        :type job_item: Dictionary
+        :param targets: List of target identities.
+        :type targets: List
+        """
+
         self.lock.acquire()
         try:
             return self.return_jobs.set(
@@ -235,7 +245,7 @@ class Server(interface.Interface):
             self.lock.release()
 
     def run_job(self, sentinel=False):
-        """Run a job interaction
+        """Run a job interaction.
 
         As the job loop executes it will interrogate the job item as returned
         from the queue. If the item contains a "targets" definition the
@@ -588,7 +598,7 @@ class Server(interface.Interface):
                     identity,
                     msg_id,
                     control,
-                    command,
+                    _,
                     data,
                     info,
                     stderr,
@@ -602,7 +612,6 @@ class Server(interface.Interface):
                         identity=identity,
                         job_id=msg_id,
                         control=control,
-                        command=command,
                         data=data,
                         info=info,
                         stderr=stderr,
@@ -779,7 +788,7 @@ class Server(interface.Interface):
         self.workers[identity] = metadata
 
     def handle_job(
-        self, identity, job_id, control, command, data, info, stderr, stdout
+        self, identity, job_id, control, data, info, stderr, stdout
     ):
         """Handle a job interaction.
 
@@ -789,8 +798,6 @@ class Server(interface.Interface):
         :type job_id: String
         :param control: Job control character
         :type control: String
-        :param command: Command
-        :type command: String
         :param data: Job data
         :type data: Dictionary
         :param info: Job info
@@ -806,12 +813,6 @@ class Server(interface.Interface):
             job_id,
             identity,
         )
-        node = identity
-        node_output = info
-        if stderr:
-            stderr = stderr
-        if stdout:
-            stdout = stdout
 
         try:
             data_item = json.loads(data)
@@ -821,8 +822,8 @@ class Server(interface.Interface):
         self._set_job_status(
             job_status=control,
             job_id=job_id,
-            identity=node,
-            job_output=node_output,
+            identity=identity,
+            job_output=info,
             job_stdout=stdout,
             job_stderr=stderr,
             execution_time=data_item.get("execution_time", 0),

--- a/directord/tests/__init__.py
+++ b/directord/tests/__init__.py
@@ -271,5 +271,5 @@ class TestDriverBase(unittest.TestCase):
         zmq.Driver = self.zmq
         messaging.Driver = self.messaging
 
-    def tearDown(self) -> None:
+    def tearDown(self):
         self.mock_driver_patched.stop()

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -55,7 +55,7 @@ class TestDriverMessaging(unittest.TestCase):
         )
         mock_send.assert_called()
         mock_send.assert_called_with(
-            "heartbeat",
+            "_heartbeat",
             "directord",
             server="directord",
             identity=ANY,
@@ -66,9 +66,36 @@ class TestDriverMessaging(unittest.TestCase):
         self.driver.heartbeat_send(10, 11, 12)
         mock_send.assert_called()
         mock_send.assert_called_with(
-            "heartbeat",
+            "_heartbeat",
             "directord",
             server="directord",
             identity=ANY,
             data=data,
+        )
+
+    @patch("directord.drivers.messaging.Driver.send")
+    def test_job_send(self, mock_send):
+        self.driver.job_send(
+            identity="TEST",
+            msg_id="XXX",
+            control="TESTcontrol",
+            command="RUN",
+            data='{"JOB": "XXX"}',
+            info="TEST INFO",
+            stderr="TEST STDERR",
+            stdout="TEST STDOUT",
+        )
+        mock_send.assert_called()
+        mock_send.assert_called_with(
+            "_job",
+            "directord",
+            server=ANY,
+            identity=ANY,
+            job_id="XXX",
+            control="TESTcontrol",
+            command="RUN",
+            data='{"JOB": "XXX"}',
+            info="TEST INFO",
+            stderr="TEST STDERR",
+            stdout="TEST STDOUT",
         )

--- a/directord/user.py
+++ b/directord/user.py
@@ -230,6 +230,13 @@ class Manage(User):
                         time.sleep(1)
 
     def analyze_job(self, job_id):
+        """Run analysis on a given job UUID.
+
+        :param job_id: Job UUID
+        :type job_id: String
+        :returns: String
+        """
+
         data = directord.send_data(
             socket_path=self.args.socket_path,
             data=json.dumps(dict(manage={"job_info": job_id})),
@@ -243,6 +250,13 @@ class Manage(User):
         return self.analyze_data(parent_id=job_id, parent_jobs=item)
 
     def analyze_parent(self, parent_id):
+        """Run analysis on a given parent UUID.
+
+        :param parent_id: Parent UUID
+        :type parent_id: String
+        :returns: String
+        """
+
         data = directord.send_data(
             socket_path=self.args.socket_path,
             data=json.dumps(dict(manage={"list_jobs": None})),
@@ -260,6 +274,15 @@ class Manage(User):
         return self.analyze_data(parent_id=parent_id, parent_jobs=parent_jobs)
 
     def analyze_data(self, parent_id, parent_jobs):
+        """Run Parent analysis.
+
+        :param parent_id: Parent UUID
+        :type parent_id: String
+        :param parent_jobs: List of all jobs for a given parent.
+        :type parent_jobs: List
+        :returns: String
+        """
+
         meta = dict(
             execution=collections.defaultdict(int),
             roundtrip=collections.defaultdict(int),

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 black
 coverage
 flake8
+flake8-docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = flake8,coverage,black-format
+envlist = flake8,coverage,black-format,black-check
 ignore_basepython_conflict = true
 
 [testenv]
@@ -16,7 +16,14 @@ commands = {posargs}
 
 [testenv:flake8]
 commands =
-    flake8 . --count --show-source --max-complexity=31 --max-line-length=79 --statistics --benchmark --ignore=H104,W503
+    flake8 . --count \
+             --show-source \
+             --max-complexity=31 \
+             --max-line-length=79 \
+             --statistics \
+             --benchmark \
+             --ignore=W503,D100,D101,D104,D105,D107,D202,D401 \
+             --exclude directord/tests,.tox
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
add flake8 docstring tests

Correct stacktrace when no messaging driver server object is None

Ensure that we're always using lazy logging

Move internal messaging driver methods to private methods

Add missing messaging job test

Remove type objects, we're not using them and they cause incompatibility
with older python versions

Signed-off-by: Kevin Carter <kecarter@redhat.com>