### PR TITLE
add missing abstract methods from messaging

### DIFF
--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -42,7 +42,7 @@ class TestDriverMessaging(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @patch("directord.drivers.messaging.Driver.send")
+    @patch("directord.drivers.messaging.Driver._send")
     def test_heartbeat_send(self, mock_send):
         self.driver.heartbeat_send(10, 11, 12)
         data = json.dumps(
@@ -73,7 +73,7 @@ class TestDriverMessaging(unittest.TestCase):
             data=data,
         )
 
-    @patch("directord.drivers.messaging.Driver.send")
+    @patch("directord.drivers.messaging.Driver._send")
     def test_job_send(self, mock_send):
         self.driver.job_send(
             identity="TEST",


### PR DESCRIPTION
This change updates the messaging driver so that it contains all of the
required public methods from the driver abstract. This should help
solidify everything we need to do to get the messaging driver prod-ready.

Non-specific driver methods that are not intended to be public have been
prefixed with an underline.

Signed-off-by: Kevin Carter <kecarter@redhat.com>