### PR TITLE
Add exposed message ID to heartbeats

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,11 +64,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -114,11 +114,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -165,11 +165,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -220,11 +220,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -268,11 +268,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -315,11 +315,11 @@ jobs:
                                                              --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -379,11 +379,11 @@ jobs:
                                              --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -445,11 +445,11 @@ jobs:
                                              --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -493,11 +493,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -578,11 +578,11 @@ jobs:
           fi
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()
@@ -689,11 +689,11 @@ jobs:
                                               --check
       - name: Generate log details
         run: |
+          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
+          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
           sudo /opt/directord/bin/directord manage --list-nodes &> /tmp/directord-nodes.log
           sudo /opt/directord/bin/directord manage --dump-cache &> /tmp/directord-cache.log
           sudo /opt/directord/bin/directord manage --export-jobs /tmp/directord-jobs-export.log
-          sudo journalctl -u directord-client -n 2000 &> /tmp/directord-client.log || true
-          sudo journalctl -u directord-server -n 2000 &> /tmp/directord-server.log || true
         if: failure()
       - name: Upload build Log artifacts on failure
         if: failure()

--- a/directord/drivers/zmq.py
+++ b/directord/drivers/zmq.py
@@ -691,10 +691,19 @@ class Driver(drivers.BaseDriver):
         :type version: String
         """
 
+        job_id = utils.get_uuid()
+        self.log.debug(
+            "Job [ %s ] sending heartbeat from [ %s ] to server",
+            job_id,
+            self.identity,
+        )
+
         return self.job_send(
             control=self.heartbeat_notice,
+            msg_id=job_id,
             data=json.dumps(
                 {
+                    "job_id": job_id,
                     "version": version,
                     "host_uptime": host_uptime,
                     "agent_uptime": agent_uptime,

--- a/directord/meta.py
+++ b/directord/meta.py
@@ -12,7 +12,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __author__ = "Kevin Carter"
 __email__ = "kevin@cloudnull.com"
 __driver_default__ = "zmq"

--- a/directord/server.py
+++ b/directord/server.py
@@ -779,10 +779,6 @@ class Server(interface.Interface):
         :type data: Dict
         """
 
-        self.log.debug(
-            "Received Heartbeat from [ %s ]",
-            identity,
-        )
         expire = self.driver.get_expiry(
             heartbeat_interval=self.heartbeat_interval,
         )
@@ -795,6 +791,12 @@ class Server(interface.Interface):
             else:
                 if loaded_data:
                     metadata.update(loaded_data)
+
+        self.log.debug(
+            "Job [ %s ] received Heartbeat from [ %s ]",
+            loaded_data["job_id"],
+            identity,
+        )
 
         if "machine_id" in metadata:
             machine_id = metadata.get("machine_id")

--- a/directord/tests/test_drivers_messaging.py
+++ b/directord/tests/test_drivers_messaging.py
@@ -42,11 +42,14 @@ class TestDriverMessaging(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @patch("directord.utils.get_uuid", autospec=True)
     @patch("directord.drivers.messaging.Driver._send")
-    def test_heartbeat_send(self, mock_send):
+    def test_heartbeat_send(self, mock_send, mock_get_uuid):
+        mock_get_uuid.return_value = "XXX"
         self.driver.heartbeat_send(10, 11, 12)
         data = json.dumps(
             {
+                "job_id": "XXX",
                 "version": 12,
                 "host_uptime": 10,
                 "agent_uptime": 11,
@@ -58,8 +61,15 @@ class TestDriverMessaging(unittest.TestCase):
         mock_send.assert_called_with(
             method="_heartbeat",
             topic="directord",
+            server=ANY,
             identity=ANY,
+            job_id="XXX",
+            control="\x05",
+            command=None,
             data=data,
+            info=None,
+            stderr=None,
+            stdout=None,
         )
 
         self.driver.identity = "foohost"
@@ -68,8 +78,15 @@ class TestDriverMessaging(unittest.TestCase):
         mock_send.assert_called_with(
             method="_heartbeat",
             topic="directord",
-            identity=ANY,
+            server=ANY,
+            identity="foohost",
+            job_id="XXX",
+            control="\x05",
+            command=None,
             data=data,
+            info=None,
+            stderr=None,
+            stdout=None,
         )
 
     @patch("directord.drivers.messaging.Driver._send")


### PR DESCRIPTION
This change will add an exposed message ID to all heartbeat messages
making it clearer when heartbeat log entries are created.

Closes #260

Signed-off-by: Kevin Carter <kevin@cloudnull.com>