### PR TITLE
cleanup default dev catalog

### DIFF
--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -106,7 +106,7 @@ with open('/etc/directord/config.yaml', 'w') as f:
     f.write(yaml.safe_dump(config, default_flow_style=False))
 EOC
 
-if [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
+if [ "${DRIVER}" == "zmq" ] && [ ! -f "/etc/directord/private_keys/server.key_secret" ]; then
   ${VENV_PATH}/bin/directord manage --generate-keys
 fi
 

--- a/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
+++ b/tools/directord-dev-bootstrap-zmq-encryption-catalog.yaml
@@ -32,6 +32,7 @@ directord_clients:
       except FileNotFoundError:
           config = dict()
       config['server_address'] = "{{ directord_server['targets'][0]['host'] }}"
+      config['zmq_curve_encryption'] = True
       with open('/etc/directord/config.yaml', 'w') as f:
           f.write(yaml.safe_dump(config, default_flow_style=False))
       EOC

--- a/tools/directord-dev-bootstrap-zmq.yaml
+++ b/tools/directord-dev-bootstrap-zmq.yaml
@@ -1,0 +1,31 @@
+---
+
+directord_server:
+  jobs:
+  - ADD: dev-setup.sh dev-setup.sh
+  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo /opt/directord/bin/directord-server-systemd
+  - RUN: sudo systemctl daemon-reload
+  - RUN: sudo systemctl enable directord-server.service
+  - RUN: sudo systemctl restart directord-server.service
+
+directord_clients:
+  jobs:
+  - ADD: dev-setup.sh dev-setup.sh
+  - RUN: sudo bash dev-setup.sh
+  - RUN: sudo /opt/directord/bin/directord-client-systemd
+  - RUN: |-
+      sudo python3 <<EOC
+      import yaml
+      try:
+          with open('/etc/directord/config.yaml') as f:
+              config = yaml.safe_load(f)
+      except FileNotFoundError:
+          config = dict()
+      config['server_address'] = "{{ directord_server['targets'][0]['host'] }}"
+      with open('/etc/directord/config.yaml', 'w') as f:
+          f.write(yaml.safe_dump(config, default_flow_style=False))
+      EOC
+  - RUN: sudo systemctl daemon-reload
+  - RUN: sudo systemctl enable directord-client.service
+  - RUN: sudo systemctl restart directord-client.service


### PR DESCRIPTION
The default dev catalog is now prefixed with the driver. A new dev
catalog has been created to show how you can run with encryption.

Signed-off-by: Kevin Carter <kecarter@redhat.com>