### PR TITLE
Add option to name orchestrations and jobs

### DIFF
--- a/directord/main.py
+++ b/directord/main.py
@@ -689,7 +689,7 @@ def main():
             else:
                 if args.list_jobs:
                     restrict_headings = [
-                        "PARENT_JOB_ID",
+                        "PARENT_JOB_NAME",
                         "VERB",
                         "EXECUTION_TIME",
                         "PROCESSING",

--- a/directord/mixin.py
+++ b/directord/mixin.py
@@ -48,6 +48,8 @@ class Mixin:
         restrict=None,
         parent_id=None,
         parent_sha3_224=None,
+        parent_name=None,
+        job_name=None,
         return_raw=False,
         parent_async=False,
     ):
@@ -75,7 +77,11 @@ class Mixin:
         :param parent_id: Set the parent UUID for execution jobs.
         :type parent_id: String
         :param parent_sha3_224: Set the parent sha3_224 for execution jobs.
-        :type parent_id: String
+        :type parent_sha3_224: String
+        :param parent_name: Set the parent name for execution jobs.
+        :type parent_name: String
+        :param job_name: Set the job name.
+        :type job_name: String
         :param return_raw: Enable a raw return from the server.
         :type return_raw: Boolean
         :param parent_async: Enable a parent job to run asynchronously.
@@ -117,6 +123,12 @@ class Mixin:
 
         if parent_sha3_224:
             data["parent_sha3_224"] = parent_sha3_224
+
+        if parent_name:
+            data["parent_name"] = parent_name
+
+        if job_name:
+            data["job_name"] = job_name
 
         if restrict:
             data["restrict"] = restrict
@@ -174,6 +186,7 @@ class Mixin:
         job_to_run = list()
         for orchestrate in orchestrations:
             parent_sha3_224 = utils.object_sha3_224(obj=orchestrate)
+            parent_name = orchestrate.get("name")
             parent_id = utils.get_uuid()
             targets = defined_targets or orchestrate.get("targets", list())
 
@@ -190,6 +203,7 @@ class Mixin:
 
             for job in orchestrate["jobs"]:
                 arg_vars = job.pop("vars", None)
+                job_name = job.pop("name", None)
                 key, value = next(iter(job.items()))
                 job_to_run.append(
                     dict(
@@ -201,6 +215,8 @@ class Mixin:
                         ignore_cache=ignore_cache,
                         parent_id=parent_id,
                         parent_sha3_224=parent_sha3_224,
+                        parent_name=parent_name,
+                        job_name=job_name,
                         return_raw=return_raw,
                         parent_async=parent_async,
                     )
@@ -219,17 +235,17 @@ class Mixin:
                 tabulated_data.extend(
                     [
                         count,
-                        job["parent_sha3_224"],
+                        job["parent_name"] or job["parent_sha3_224"],
                         item["verb"],
                         exec_str,
-                        item["job_sha3_224"],
+                        job["job_name"] or item["job_sha3_224"],
                     ]
                 )
                 return_data.append(tabulated_data)
                 count += 1
             utils.print_tabulated_data(
                 data=return_data,
-                headers=["count", "parent_sha", "verb", "exec", "job_sha"],
+                headers=["count", "parent", "verb", "exec", "job"],
             )
             return []
         else:

--- a/directord/server.py
+++ b/directord/server.py
@@ -245,8 +245,14 @@ class Server(interface.Interface):
                     "_nodes": list(sorted(_nodes)),
                     "VERB": job_item["verb"],
                     "JOB_SHA3_224": job_item["job_sha3_224"],
+                    "JOB_NAME": job_item.get(
+                        "job_name", job_item["job_sha3_224"]
+                    ),
                     "JOB_DEFINITION": job_item,
                     "PARENT_JOB_ID": job_item.get("parent_id"),
+                    "PARENT_JOB_NAME": job_item.get(
+                        "parent_name", job_item.get("parent_id")
+                    ),
                     "_createtime": time.time(),
                     "_executiontime": dict(),
                     "_roundtripltime": dict(),

--- a/directord/tests/test_mixin.py
+++ b/directord/tests/test_mixin.py
@@ -21,7 +21,7 @@ from directord import mixin
 from directord import tests
 
 
-TEST_FINGER_PRINTS = """count    parent_sha                                                verb    exec      job_sha
+TEST_FINGER_PRINTS = """count    parent                                                    verb    exec      job
 -------  --------------------------------------------------------  ------  --------  --------------------------------------------------------
 0        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command1  ea5b3554e61a173c25152ad6fe29b178f66b0e3727556995f5816d7e
 1        5bc535e8fa927e4a4ab9ca188f8b560935b32a00dacc4f9e76b05d08  RUN     command2  a12748d70957f1f2d0ea3d2aae5af73983d8a0563f7b5a0ccd0b2767

--- a/directord/tests/test_server.py
+++ b/directord/tests/test_server.py
@@ -384,8 +384,51 @@ class TestServer(tests.TestDriverBase):
                 },
                 "_nodes": ["test-node1", "test-node2"],
                 "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "ZZZ",
                 "STDERR": {},
                 "STDOUT": {},
+                "JOB_NAME": "YYY",
+                "JOB_SHA3_224": "YYY",
+                "VERB": "TEST",
+                "_createtime": ANY,
+                "_processing": ANY,
+                "_executiontime": ANY,
+                "_roundtripltime": ANY,
+            },
+        )
+
+    def test_create_return_jobs_named(self):
+        self.maxDiff = 1024
+        self.server.return_jobs = datastores.BaseDocument()
+        status = self.server.create_return_jobs(
+            task="XXX",
+            job_item={
+                "verb": "TEST",
+                "job_sha3_224": "YYY",
+                "job_name": "test job name",
+                "parent_id": "ZZZ",
+                "parent_name": "test parent name",
+            },
+            targets=["test-node1", "test-node2"],
+        )
+        self.assertDictEqual(
+            status,
+            {
+                "ACCEPTED": True,
+                "INFO": {},
+                "JOB_DEFINITION": {
+                    "verb": "TEST",
+                    "job_sha3_224": "YYY",
+                    "job_name": "test job name",
+                    "parent_id": "ZZZ",
+                    "parent_name": "test parent name",
+                },
+                "_nodes": ["test-node1", "test-node2"],
+                "PARENT_JOB_ID": "ZZZ",
+                "PARENT_JOB_NAME": "test parent name",
+                "STDERR": {},
+                "STDOUT": {},
+                "JOB_NAME": "test job name",
                 "JOB_SHA3_224": "YYY",
                 "VERB": "TEST",
                 "_createtime": ANY,

--- a/docs/orchestrations.md
+++ b/docs/orchestrations.md
@@ -21,6 +21,10 @@ The values available within an orchestration file are `targets` and `jobs`.
 > Asynchronous orchestrations allow operators to run many orchestrations at
   the same time while following the defined task ordering.
 
+Optionally, an orchestration can be named. This is done through the use of
+the `name` key. When orchestrations are named, both the job list and
+fingerprint output will use the defined `name` in the returned
+information.
 
 ##### Example Orchestrations
 
@@ -98,3 +102,20 @@ adhoc execution.
 ``` shell
 $ directord orchestrate ${ORCHESTRATION_FILE_NAME} [<switches> ...]
 ```
+
+#### Jobs breakdown
+
+Each **job** within the `jobs` list is a dictionary item with the fist key
+ALWAYS representing the verb used within the given job. This verb corresponds
+to a known component.
+
+All jobs can make use of the `vars` key and `name` keys. Both of those
+options are useful when defining complex variables, which may be difficult
+to express inline or within a "string" format.
+
+* `vars` is a dictionary of arguments that will be passed back into the
+  execution options for a given job
+
+* `name` is a string object which provides a human friendly name
+  for a job definition. This name can be used for an improved UX when
+  looking into job debug information.

--- a/orchestrations/functional-tests.yaml
+++ b/orchestrations/functional-tests.yaml
@@ -2,6 +2,12 @@
 #
 ---
 
+- name: Functional test parent
+  jobs:
+  - RUN: echo named job
+    name: Job name test
+
+
 - jobs:
   # Test run
   - RUN: echo hello world


### PR DESCRIPTION
Both orchestrations and jobs can now be named. This will allow users
to define names for given orchestrations and see that returned
information at a glance, which greatly improves the UX when needing
to debug given orchestrations and tasks.

Closes #261

Signed-off-by: Kevin Carter <kecarter@redhat.com>